### PR TITLE
Rendered context icon depending on the type

### DIFF
--- a/spoti-friends/src/common/realm/RealmDatabase.swift
+++ b/spoti-friends/src/common/realm/RealmDatabase.swift
@@ -5,7 +5,7 @@ import RealmSwift
 class RealmDatabase {
     static let shared: RealmDatabase = RealmDatabase()
     private let realm: Realm
-    private let schemaVersion: UInt64 = 13  // Increment this when making schema changes
+    private let schemaVersion: UInt64 = 14  // Increment this when making schema changes
     
     init() {
         // Use this configuration when opening realms

--- a/spoti-friends/src/friendActivity/viewModels/FriendActivityViewModel.swift
+++ b/spoti-friends/src/friendActivity/viewModels/FriendActivityViewModel.swift
@@ -36,7 +36,6 @@ class FriendActivityViewModel: ObservableObject {
                                                      backgroundColor: backgroundColor)
                 friendActivities.append(activity)
             }
-            print(friendActivities)
             self.friendActivites = friendActivities
         } catch {
             printError("\(error)")

--- a/spoti-friends/src/friendActivity/viewModels/FriendActivityViewModel.swift
+++ b/spoti-friends/src/friendActivity/viewModels/FriendActivityViewModel.swift
@@ -36,6 +36,7 @@ class FriendActivityViewModel: ObservableObject {
                                                      backgroundColor: backgroundColor)
                 friendActivities.append(activity)
             }
+            print(friendActivities)
             self.friendActivites = friendActivities
         } catch {
             printError("\(error)")

--- a/spoti-friends/src/friendActivity/views/ListeningActivityCard.swift
+++ b/spoti-friends/src/friendActivity/views/ListeningActivityCard.swift
@@ -36,7 +36,7 @@ struct ListeningActivityCard: View, Identifiable {
                 ProfileImage(imageName: spotifyId, width: 56, height: 56)
                     .environmentObject(friendActivityViewModel)
                 
-                ListeningActivityDetails(username: displayName, currentTrack: track)
+                ListeningActivityDetails(displayName: displayName, currentTrack: track)
                     .foregroundStyle(fontColor)
                 
                 AlbumCover(album: album, width: 80, height: 80)
@@ -55,19 +55,37 @@ struct ListeningActivityCard: View, Identifiable {
 /// The View that renders the details for a listening activity item.
 ///
 /// - Parameters:
-///   - username: The username for the user whose listenting activity this is.
+///   - displayName: The display name for the user whose listenting activity this is.
 ///   - track: The current or most recent track to display for the user.
 ///
 /// - Returns: A View for the Listening Activity Details.
 struct ListeningActivityDetails: View {
-    let username: String
+    let displayName: String
     let currentTrack: CurrentOrMostRecentTrack
+    @State var contextIcon: Image
+    
+    init(displayName: String, currentTrack: CurrentOrMostRecentTrack) {
+        self.displayName = displayName
+        self.currentTrack = currentTrack
+        self.contextIcon = getImageForContextType()
+        
+        func getImageForContextType() -> Image {
+            let contextType = currentTrack.track?.context?.type
+            
+            switch contextType {
+            case .album: return Image(systemName: "smallcircle.circle")
+            case .artist: return Image(systemName: "person.fill")
+            case .playlist: return Image(systemName: "music.note")
+            default: return Image(systemName: "music.note")
+            }
+        }
+    }
     
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
             // Username row
             HStack {
-                Text(username)
+                Text(displayName)
                     .fontWeight(.medium)
                 Spacer()
                 Image(.nowPlaying)
@@ -87,9 +105,9 @@ struct ListeningActivityDetails: View {
             
             // Context details row
             HStack {
-                Image(systemName: "music.note.list")
+                contextIcon
                     .padding(.trailing, -6)
-                    .fontWeight(.ultraLight)
+//                    .fontWeight()
                 Text(currentTrack.track?.context?.name ?? "Error")
                     .lineLimit(1)
             }

--- a/spoti-friends/src/spotify/models/SpotifyProfile.swift
+++ b/spoti-friends/src/spotify/models/SpotifyProfile.swift
@@ -86,4 +86,22 @@ class Album: Object, SpotifyResource {
 class TrackContext: Object, SpotifyResource {
     @Persisted var spotifyUri: String
     @Persisted var name: String
+    @Persisted var type: ContextType
+    
+    /// The context which this track is being played in
+    enum ContextType: String, PersistableEnum {
+        case album
+        case artist
+        case playlist
+        case show
+    }
+    
+    func extractContextTypeFromUri() -> ContextType {
+        let uriComponents = self.spotifyUri.split(separator: ":")
+        var extractedType = ""
+        if uriComponents.count >= 2 {
+            extractedType = String(uriComponents[uriComponents.count - 2])
+        }
+        return ContextType(rawValue: extractedType) ?? .playlist
+    }
 }

--- a/spoti-friends/src/spotify/models/mocked/TrackContextMock.swift
+++ b/spoti-friends/src/spotify/models/mocked/TrackContextMock.swift
@@ -2,14 +2,15 @@ import Foundation
 
 /// Struct containing mock TrackContext objects.
 struct TrackContextMock {
-    static let playlistAllMySongs = createMockTrackContext(name: "all my songs")
-    static let albumSour = createMockTrackContext(name: "SOUR")
-    static let artistJonBellion = createMockTrackContext(name: "Jon Bellion")
+    static let playlistAllMySongs = createMockTrackContext(spotifyUri: "spotify:playlist:uri", name: "all my songs")
+    static let albumSour = createMockTrackContext(spotifyUri: "spotify:album:uri", name: "SOUR")
+    static let artistJonBellion = createMockTrackContext(spotifyUri: "spotify:artist:uri", name: "Jon Bellion")
    
-    static func createMockTrackContext(spotifyUri: String = "", name: String) -> TrackContext {
+    static func createMockTrackContext(spotifyUri: String = "spotify:playlist:uri", name: String) -> TrackContext {
         let context = TrackContext()
         context.spotifyUri = spotifyUri
         context.name = name
+        context.type = context.extractContextTypeFromUri()
         return context
     }
 }

--- a/spoti-friends/src/spotify/spotifyAPI/helpers/getListOfUsersFriends.swift
+++ b/spoti-friends/src/spotify/spotifyAPI/helpers/getListOfUsersFriends.swift
@@ -123,6 +123,7 @@ private struct BuddylistResponseObject: Codable {
             let context = TrackContext()
             context.spotifyUri = self.uri
             context.name = self.name
+            context.type = context.extractContextTypeFromUri()
             return context
         }
     }


### PR DESCRIPTION
#### Changes
- Added `type` field to `TrackContext`
  - Updated database schema version
  - Set `type` value from `spotifyUri` value
- Rendered context icon in `ListeningActivityDetails` depending on the `type`