### PR TITLE
Added links to listening activity card

### DIFF
--- a/spoti-friends/src/common/realm/RealmDatabase.swift
+++ b/spoti-friends/src/common/realm/RealmDatabase.swift
@@ -5,7 +5,7 @@ import RealmSwift
 class RealmDatabase {
     static let shared: RealmDatabase = RealmDatabase()
     private let realm: Realm
-    private let schemaVersion: UInt64 = 14  // Increment this when making schema changes
+    private let schemaVersion: UInt64 = 15  // Increment this when making schema changes
     
     init() {
         // Use this configuration when opening realms

--- a/spoti-friends/src/friendActivity/mocked/ListeningActivityCardMock.swift
+++ b/spoti-friends/src/friendActivity/mocked/ListeningActivityCardMock.swift
@@ -5,30 +5,21 @@ import SwiftUI
 struct ListeningActivityCardMock {
     static let allCards = [michaelScottActivity, dwightSchruteActivity, stanleyHudsonActivity]
     
-    static let michaelScottActivity = createMockListeningActivityCard(album: AlbumMock.zachBryan,
-                                                                      displayName: SpotifyProfileMock.michaelScott.displayName,
-                                                                      track: CurrentOrMostRecentTrackMock.iRememberEverything,
+    static let michaelScottActivity = createMockListeningActivityCard(profile: SpotifyProfileMock.michaelScott,
                                                                       backgroundColor: Color.gray)
     
-    static let dwightSchruteActivity = createMockListeningActivityCard(album: AlbumMock.sour,
-                                                                       displayName: SpotifyProfileMock.dwightSchrute.displayName,
-                                                                       track: CurrentOrMostRecentTrackMock.traitor,
+    static let dwightSchruteActivity = createMockListeningActivityCard(profile: SpotifyProfileMock.dwightSchrute,
                                                                        backgroundColor: Color.pink)
     
-    static let stanleyHudsonActivity = createMockListeningActivityCard(album: AlbumMock.theDefinition,
-                                                                       displayName: SpotifyProfileMock.stanleyHudson.displayName,
-                                                                       track: CurrentOrMostRecentTrackMock.luxury,
+    static let stanleyHudsonActivity = createMockListeningActivityCard(profile: SpotifyProfileMock.stanleyHudson,
                                                                        backgroundColor: Color.yellow)
     
-    static func createMockListeningActivityCard(spotifyId: String = UUID().uuidString,
-                                                 album: Album,
-                                                 displayName: String,
-                                                 track: CurrentOrMostRecentTrack,
-                                                 backgroundColor: Color) -> ListeningActivityCard {
-        return ListeningActivityCard(spotifyId: spotifyId,
-                                     album: album,
-                                     displayName: displayName,
-                                     track: track,
-                                     backgroundColor: backgroundColor)
+    static func createMockListeningActivityCard(profile: SpotifyProfile, backgroundColor: Color) -> ListeningActivityCard {
+        return ListeningActivityCard(profile: profile, backgroundColor: backgroundColor)
+//        return ListeningActivityCard(spotifyId: spotifyId,
+//                                     album: album,
+//                                     displayName: displayName,
+//                                     track: track,
+//                                     backgroundColor: backgroundColor)
     }
 }

--- a/spoti-friends/src/friendActivity/mocked/ListeningActivityCardMock.swift
+++ b/spoti-friends/src/friendActivity/mocked/ListeningActivityCardMock.swift
@@ -16,10 +16,5 @@ struct ListeningActivityCardMock {
     
     static func createMockListeningActivityCard(profile: SpotifyProfile, backgroundColor: Color) -> ListeningActivityCard {
         return ListeningActivityCard(profile: profile, backgroundColor: backgroundColor)
-//        return ListeningActivityCard(spotifyId: spotifyId,
-//                                     album: album,
-//                                     displayName: displayName,
-//                                     track: track,
-//                                     backgroundColor: backgroundColor)
     }
 }

--- a/spoti-friends/src/friendActivity/viewModels/FriendActivityViewModel.swift
+++ b/spoti-friends/src/friendActivity/viewModels/FriendActivityViewModel.swift
@@ -23,17 +23,13 @@ class FriendActivityViewModel: ObservableObject {
     @MainActor public func setFriendActivity() async throws -> Void {
         do {
             let accessToken = try await self.user.getInternalAPIAccessToken().accessToken
-            let friends = try await SpotifyAPI.shared.getListOfUsersFriends(internalAPIAccessToken: accessToken)
+            let friends: [SpotifyProfile] = try await SpotifyAPI.shared.getListOfUsersFriends(internalAPIAccessToken: accessToken)
             var friendActivities: [ListeningActivityCard] = []
             for friend in friends.reversed() {
                 await storeProfilePictureLocally(imageName: friend.spotifyId, link: friend.image)
                 
                 let backgroundColor = Color(try await getAccentColorForImage((friend.currentOrMostRecentTrack?.track?.album!.image)!))
-                let activity = ListeningActivityCard(spotifyId: friend.spotifyId,
-                                                     album: (friend.currentOrMostRecentTrack?.track?.album)!,
-                                                     displayName: friend.displayName,
-                                                     track: friend.currentOrMostRecentTrack!,
-                                                     backgroundColor: backgroundColor)
+                let activity = ListeningActivityCard(profile: friend, backgroundColor: backgroundColor)
                 friendActivities.append(activity)
             }
             self.friendActivites = friendActivities

--- a/spoti-friends/src/friendActivity/views/FriendActivityView.swift
+++ b/spoti-friends/src/friendActivity/views/FriendActivityView.swift
@@ -15,14 +15,8 @@ struct FriendActivityView: View {
             ScrollView {
                 VStack(alignment: .center) {
                     ForEach(friendActivityViewModel.friendActivites) { activity in
-                        ListeningActivityCard(
-                            spotifyId: activity.spotifyId,
-                            album: activity.album,
-                            displayName: activity.displayName,
-                            track: activity.track,
-                            backgroundColor: activity.backgroundColor
-                        )
-                        .environmentObject(friendActivityViewModel)
+                        activity
+                            .environmentObject(friendActivityViewModel)
                         
                     }
                 }

--- a/spoti-friends/src/friendActivity/views/ListeningActivityCard.swift
+++ b/spoti-friends/src/friendActivity/views/ListeningActivityCard.swift
@@ -69,7 +69,6 @@ struct ListeningActivityCard: View, Identifiable {
     let user = UserMock.userJimHalpert
     let profile = SpotifyProfileMock.michaelScott
     
-    ListeningActivityCard(profile: profile, backgroundColor: Color.gray
-    )
+    ListeningActivityCard(profile: profile, backgroundColor: Color.gray)
     .environmentObject(FriendActivityViewModel(user: user, friendActivites: []))
 }

--- a/spoti-friends/src/friendActivity/views/ListeningActivityCard.swift
+++ b/spoti-friends/src/friendActivity/views/ListeningActivityCard.swift
@@ -3,29 +3,26 @@ import SwiftUI
 /// The View that renders a Listening Acvitiy Component.
 ///
 /// - Parameters:
-///   - spotifyId: The Spotify ID for the user whose activity this is.
-///   - album: The album for the current track.
-///   - displayName: The display name for the user whose listenting activity this is.
+///   - profile: The Spotify Profile that is associated with this listening activity.
 ///   - track: The current or most recent track to display for the user.
+///   - album: The album for the current track.
 ///   - backgroundColor: The background color to set for this item.
 ///
 /// - Returns: A View for the Listening Activity Card.
 struct ListeningActivityCard: View, Identifiable {
     let id: String
-    let spotifyId: String
-    let album: Album
-    let displayName: String
+    var profile: SpotifyProfile
     let track: CurrentOrMostRecentTrack
+    let album: Album
     let backgroundColor: Color;
     @State var fontColor: Color
     @EnvironmentObject var friendActivityViewModel: FriendActivityViewModel
     
     init(profile: SpotifyProfile, backgroundColor: Color) {
         self.id = profile.spotifyId
-        self.spotifyId = profile.spotifyId
-        self.album = (profile.currentOrMostRecentTrack?.track?.album)!
-        self.displayName = profile.displayName
+        self.profile = profile
         self.track = profile.currentOrMostRecentTrack!
+        self.album = (profile.currentOrMostRecentTrack?.track?.album)!
         self.backgroundColor = backgroundColor
         self.fontColor = Color(backgroundColor).isDarkBackground() ? Color.white : Color.black
     }
@@ -33,18 +30,21 @@ struct ListeningActivityCard: View, Identifiable {
     var body: some View {
         VStack {
             HStack {
-                ZStack {
-                    ProfileImage(imageName: spotifyId, width: 56, height: 56)
-                        .environmentObject(friendActivityViewModel)
-                    if track.playedWithinLastFifteenMinutes {   
-                        Circle()
-                            .fill(Color.blue)
-                            .frame(width: 12, height: 12)
-                            .offset(x: 22, y: -18)
+                Link(destination: URL(string: profile.spotifyUri)!) {
+                    ZStack {
+                        ProfileImage(imageName: profile.spotifyId, width: 56, height: 56)
+                            .environmentObject(friendActivityViewModel)
+                        if track.playedWithinLastFifteenMinutes {
+                            Circle()
+                                .fill(Color.blue)
+                                .frame(width: 12, height: 12)
+                                .offset(x: 22, y: -18)
+                        }
                     }
                 }
+                .buttonStyle(PlainButtonStyle())
                 
-                ListeningActivityDetails(displayName: displayName, currentTrack: track)
+                ListeningActivityDetails(displayName: profile.displayName, currentTrack: track)
                     .foregroundStyle(fontColor)
                 
                 AlbumCover(album: album, width: 80, height: 80)

--- a/spoti-friends/src/friendActivity/views/ListeningActivityCard.swift
+++ b/spoti-friends/src/friendActivity/views/ListeningActivityCard.swift
@@ -29,6 +29,7 @@ struct ListeningActivityCard: View, Identifiable {
     
     var body: some View {
         VStack {
+            // Profile Image
             HStack {
                 Link(destination: URL(string: profile.spotifyUri)!) {
                     ZStack {
@@ -44,11 +45,15 @@ struct ListeningActivityCard: View, Identifiable {
                 }
                 .buttonStyle(PlainButtonStyle())
                 
-                ListeningActivityDetails(displayName: profile.displayName, currentTrack: track)
+                // Listening Activity Details
+                ListeningActivityDetails(profile: profile, currentTrack: track)
                     .foregroundStyle(fontColor)
                 
-                AlbumCover(album: album, width: 80, height: 80)
-                    .padding(.leading, 4)
+                // Album Cover
+                Link(destination: URL(string: album.spotifyUri)!) {
+                    AlbumCover(album: album, width: 80, height: 80)
+                        .padding(.leading, 4)
+                }
             }
             .padding(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 8))
             .frame(maxWidth: 600, maxHeight: 96)

--- a/spoti-friends/src/friendActivity/views/ListeningActivityCard.swift
+++ b/spoti-friends/src/friendActivity/views/ListeningActivityCard.swift
@@ -20,12 +20,12 @@ struct ListeningActivityCard: View, Identifiable {
     @State var fontColor: Color
     @EnvironmentObject var friendActivityViewModel: FriendActivityViewModel
     
-    init(spotifyId: String, album: Album, displayName: String, track: CurrentOrMostRecentTrack, backgroundColor: Color) {
-        self.id = spotifyId
-        self.spotifyId = spotifyId
-        self.album = album
-        self.displayName = displayName
-        self.track = track
+    init(profile: SpotifyProfile, backgroundColor: Color) {
+        self.id = profile.spotifyId
+        self.spotifyId = profile.spotifyId
+        self.album = (profile.currentOrMostRecentTrack?.track?.album)!
+        self.displayName = profile.displayName
+        self.track = profile.currentOrMostRecentTrack!
         self.backgroundColor = backgroundColor
         self.fontColor = Color(backgroundColor).isDarkBackground() ? Color.white : Color.black
     }
@@ -63,14 +63,8 @@ struct ListeningActivityCard: View, Identifiable {
 #Preview {
     let user = UserMock.userJimHalpert
     let profile = SpotifyProfileMock.michaelScott
-    let album = AlbumMock.zachBryan
-    let track = CurrentOrMostRecentTrackMock.iRememberEverything
     
-    ListeningActivityCard(spotifyId: profile.spotifyId,
-                          album: album,
-                          displayName: profile.displayName,
-                          track: track,
-                          backgroundColor: Color.gray
+    ListeningActivityCard(profile: profile, backgroundColor: Color.gray
     )
     .environmentObject(FriendActivityViewModel(user: user, friendActivites: []))
 }

--- a/spoti-friends/src/friendActivity/views/ListeningActivityDetails.swift
+++ b/spoti-friends/src/friendActivity/views/ListeningActivityDetails.swift
@@ -5,7 +5,7 @@ import SwiftUI
 /// - Parameters:
 ///   - profile: The Spotify Profile for the user whose listening activity this is.
 ///   - currentTrack: The current or most recent track to display for the user.
-///   - track: The actual `Track` object for the `currentTrack`.
+///   - trackDetails: The actual `Track` object for the `currentTrack`.
 ///   - artist: The artist of `track`.
 ///
 /// - Returns: A View for the Listening Activity Details.

--- a/spoti-friends/src/friendActivity/views/ListeningActivityDetails.swift
+++ b/spoti-friends/src/friendActivity/views/ListeningActivityDetails.swift
@@ -64,5 +64,5 @@ struct ListeningActivityDetails: View {
 
 #Preview {
     let details = ListeningActivityCardMock.michaelScottActivity
-    ListeningActivityDetails(displayName: details.displayName, currentTrack: details.track)
+    ListeningActivityDetails(displayName: details.profile.displayName, currentTrack: details.track)
 }

--- a/spoti-friends/src/friendActivity/views/ListeningActivityDetails.swift
+++ b/spoti-friends/src/friendActivity/views/ListeningActivityDetails.swift
@@ -7,6 +7,7 @@ import SwiftUI
 ///   - currentTrack: The current or most recent track to display for the user.
 ///   - trackDetails: The actual `Track` object for the `currentTrack`.
 ///   - artist: The artist of `track`.
+///   - context: The context from which `currentTrack` was played.
 ///
 /// - Returns: A View for the Listening Activity Details.
 struct ListeningActivityDetails: View {
@@ -14,6 +15,7 @@ struct ListeningActivityDetails: View {
     let currentTrack: CurrentOrMostRecentTrack
     let trackDetails: Track
     let artist: Artist
+    let context: TrackContext
     @State var contextIcon: Image
     
     init(profile: SpotifyProfile, currentTrack: CurrentOrMostRecentTrack) {
@@ -21,6 +23,7 @@ struct ListeningActivityDetails: View {
         self.currentTrack = currentTrack
         self.trackDetails = currentTrack.track!
         self.artist = (currentTrack.track?.artist)!
+        self.context = (currentTrack.track?.context)!
         self.contextIcon = getImageForContextType()
         
         func getImageForContextType() -> Image {
@@ -62,18 +65,7 @@ struct ListeningActivityDetails: View {
             }
             
             // Context details row
-            // Wrap the row with a link to the context item if it is not nil.
-            if let context = trackDetails.context {
-                Link(destination: URL(string: context.spotifyUri)!) {
-                    HStack {
-                        contextIcon
-                            .padding(.trailing, -6)
-                        Text(trackDetails.context?.name ?? "Error")
-                            .lineLimit(1)
-                    }
-                }
-            }
-            else {
+            Link(destination: URL(string: context.spotifyUri)!) {
                 HStack {
                     contextIcon
                         .padding(.trailing, -6)

--- a/spoti-friends/src/spotify/models/SpotifyProfile.swift
+++ b/spoti-friends/src/spotify/models/SpotifyProfile.swift
@@ -2,6 +2,13 @@ import Foundation
 import RealmSwift
 
 /// Class representing a `SpotifyProfile` object.
+///
+/// - Parameters:
+///   - spotifyId: The Spotify ID associated with this Spotify profile.
+///   - spotifyUri: The Spotify unique resource identifier for this Spotify profile.
+///   - displayName: The display name associated with this Spotify profile.
+///   - image: The profile image for this Spotify profile.
+///   - currentOrMostRecentTrack: The track last played (or currently playing)  by this Spotify profile.
 class SpotifyProfile: Object {
     @Persisted(primaryKey: true) var spotifyId: String
     @Persisted var spotifyUri: String

--- a/spoti-friends/src/spotify/models/mocked/ArtistMock.swift
+++ b/spoti-friends/src/spotify/models/mocked/ArtistMock.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Struct containing mock Artist objects.
 struct ArtistMock {
-    static let zachBryan = createMockArtist(name: "Zach Bryan")
-    static let oliviaRodrigo = createMockArtist(name: "Olivia Rodrigo")
-    static let jonBellion = createMockArtist(name: "Jon Bellion")
+    static let zachBryan = createMockArtist(spotifyUri: "spotify:artist:40ZNYROS4zLfyyBSs2PGe2", name: "Zach Bryan")
+    static let oliviaRodrigo = createMockArtist(spotifyUri: "spotify:artist:1McMsnEElThX1knmY4oliG", name: "Olivia Rodrigo")
+    static let jonBellion = createMockArtist(spotifyUri: "spotify:artist:50JJSqHUf2RQ9xsHs0KMHg", name: "Jon Bellion")
     
     static func createMockArtist(spotifyUri: String = "", name: String) -> Artist {
         let artist = Artist()

--- a/spoti-friends/src/spotify/models/mocked/SpotifyProfileMock.swift
+++ b/spoti-friends/src/spotify/models/mocked/SpotifyProfileMock.swift
@@ -3,10 +3,14 @@ import Foundation
 
 /// Struct containing mock Spotify Profile objects.
 struct SpotifyProfileMock {
-    static let jimHalpert = createMockSpotifyProfile(spotifyId: "Jim Halpert", track: CurrentOrMostRecentTrack())
-    static let dwightSchrute = createMockSpotifyProfile(spotifyId: "Dwight Schrute", track: CurrentOrMostRecentTrack())
-    static let michaelScott = createMockSpotifyProfile(spotifyId: "michael", track: CurrentOrMostRecentTrack())
-    static let stanleyHudson = createMockSpotifyProfile(spotifyId: "stanleythemanly", track: CurrentOrMostRecentTrack())
+    static let jimHalpert = createMockSpotifyProfile(spotifyId: "Jim Halpert",
+                                                     track: CurrentOrMostRecentTrackMock.iRememberEverything)
+    static let michaelScott = createMockSpotifyProfile(spotifyId: "michael",
+                                                       track: CurrentOrMostRecentTrackMock.iRememberEverything)
+    static let dwightSchrute = createMockSpotifyProfile(spotifyId: "Dwight Schrute",
+                                                        track: CurrentOrMostRecentTrackMock.traitor)
+    static let stanleyHudson = createMockSpotifyProfile(spotifyId: "stanleythemanly",
+                                                        track: CurrentOrMostRecentTrackMock.luxury)
     
     static func createMockSpotifyProfile(spotifyId: String, image: String = "", track: CurrentOrMostRecentTrack) -> SpotifyProfile {
         let mockSpotifyProfile = SpotifyProfile()

--- a/spoti-friends/src/spotify/models/mocked/TrackMock.swift
+++ b/spoti-friends/src/spotify/models/mocked/TrackMock.swift
@@ -2,15 +2,18 @@ import Foundation
 
 /// Struct containing mock Track objects.
 struct TrackMock {
-    static let iRememberEverything = createMockTrack(name: "I Remember Everything (feat. Kacey Musgraves)",
+    static let iRememberEverything = createMockTrack(spotifyUri: "spotify:track:4KULAymBBJcPRpk1yO4dOG",
+                                                     name: "I Remember Everything (feat. Kacey Musgraves)",
                                                      artist: ArtistMock.zachBryan,
                                                      album: AlbumMock.zachBryan,
                                                      context: TrackContextMock.playlistAllMySongs)
     
-    static let traitor = createMockTrack(name: "traitor", artist: ArtistMock.oliviaRodrigo,
+    static let traitor = createMockTrack(spotifyUri: "spotify:track:5CZ40GBx1sQ9agT82CLQCT",
+                                         name: "traitor", artist: ArtistMock.oliviaRodrigo,
                                          album: AlbumMock.sour, context: TrackContextMock.albumSour)
     
-    static let luxury = createMockTrack(name: "Luxury", artist: ArtistMock.jonBellion,
+    static let luxury = createMockTrack(spotifyUri: "spotify:track:5CgFGKdTn8R5dXGEPEX6Gm",
+                                        name: "Luxury", artist: ArtistMock.jonBellion,
                                         album: AlbumMock.theDefinition, context: TrackContextMock.artistJonBellion)
     
     static func createMockTrack(spotifyUri: String = "", name: String, artist: Artist, album: Album, context: TrackContext) -> Track {

--- a/spoti-friends/src/spotify/views/AlbumCover.swift
+++ b/spoti-friends/src/spotify/views/AlbumCover.swift
@@ -15,25 +15,23 @@ struct AlbumCover: View {
     var body: some View {
          let imageURL = URL(string: album.image)
         
-         Link (destination: URL(string: album.spotifyUri)!) {
-            AsyncImage(url: imageURL) { phase in
-                switch phase {
-                case .empty:
-                    ProgressView() // Shows a progress indicator while loading
-                case .success(let image):
-                    image
-                        .resizable()
-                case .failure:
-                    Image(systemName: "person.circle.fill")
-                        .resizable()
-                @unknown default:
-                    EmptyView()
-                }
+        AsyncImage(url: imageURL) { phase in
+            switch phase {
+            case .empty:
+                ProgressView() // Shows a progress indicator while loading
+            case .success(let image):
+                image
+                    .resizable()
+            case .failure:
+                Image(systemName: "person.circle.fill")
+                    .resizable()
+            @unknown default:
+                EmptyView()
             }
-            .aspectRatio(contentMode: .fill)
-            .frame(width: width, height: height)
-            .clipShape(RoundedRectangle(cornerRadius: 12))
         }
+        .aspectRatio(contentMode: .fill)
+        .frame(width: width, height: height)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 }
 


### PR DESCRIPTION
#### Changes
- Added links to `ListeningActivityDetails`
- Refactored `ListeningActivityCard` to take a `SpotifyProfile` object as an argument instead of the several individual fields