### PR TITLE
More graceful error handling when something goes wrong during authentication

### DIFF
--- a/spoti-friends.xcodeproj/project.pbxproj
+++ b/spoti-friends.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		CB70E89E2C80174D00F9A197 /* TrackOrArtistListPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB70E89D2C80174D00F9A197 /* TrackOrArtistListPlaceholder.swift */; };
 		CB70E8A02C8017CD00F9A197 /* ArtistList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB70E89F2C8017CD00F9A197 /* ArtistList.swift */; };
 		CB70E8A22C816AAA00F9A197 /* OpenInSpotifyButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB70E8A12C816AAA00F9A197 /* OpenInSpotifyButton.swift */; };
+		CB70E8A52C838FB400F9A197 /* SomethingWentWrongView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB70E8A42C838FB400F9A197 /* SomethingWentWrongView.swift */; };
 		CB7C05A22C0EAB3B001A0062 /* AuthErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7C05A12C0EAB3B001A0062 /* AuthErrors.swift */; };
 		CB7C05A42C0EB4DB001A0062 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7C05A32C0EB4DB001A0062 /* Utils.swift */; };
 		CB7C05A92C0EBB25001A0062 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7C05A82C0EBB25001A0062 /* User.swift */; };
@@ -119,6 +120,7 @@
 		CB70E89D2C80174D00F9A197 /* TrackOrArtistListPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackOrArtistListPlaceholder.swift; sourceTree = "<group>"; };
 		CB70E89F2C8017CD00F9A197 /* ArtistList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistList.swift; sourceTree = "<group>"; };
 		CB70E8A12C816AAA00F9A197 /* OpenInSpotifyButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenInSpotifyButton.swift; sourceTree = "<group>"; };
+		CB70E8A42C838FB400F9A197 /* SomethingWentWrongView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SomethingWentWrongView.swift; sourceTree = "<group>"; };
 		CB7C05A12C0EAB3B001A0062 /* AuthErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthErrors.swift; sourceTree = "<group>"; };
 		CB7C05A32C0EB4DB001A0062 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		CB7C05A82C0EBB25001A0062 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
@@ -194,6 +196,7 @@
 		CB0854C42C155C510088E87D /* views */ = {
 			isa = PBXGroup;
 			children = (
+				CB70E8A32C838F9E00F9A197 /* errors */,
 				CB3B61802C1F83AE0088DFA1 /* AuthenticatedView.swift */,
 				CB3B617E2C1BDFB00088DFA1 /* PageTitle.swift */,
 				CB9A9AAC2C0BB13E0073817C /* RootView.swift */,
@@ -390,6 +393,14 @@
 				CB875CAD2C315073001B364D /* FriendActivityViewModel.swift */,
 			);
 			path = viewModels;
+			sourceTree = "<group>";
+		};
+		CB70E8A32C838F9E00F9A197 /* errors */ = {
+			isa = PBXGroup;
+			children = (
+				CB70E8A42C838FB400F9A197 /* SomethingWentWrongView.swift */,
+			);
+			path = errors;
 			sourceTree = "<group>";
 		};
 		CB7C05A52C0EB8A2001A0062 /* utils */ = {
@@ -647,6 +658,7 @@
 				CB3724972C3B27CA004883D1 /* ProfileDetails.swift in Sources */,
 				CB0854CB2C1574FE0088E87D /* SpotifyProfile.swift in Sources */,
 				CB0854BC2C14D58E0088E87D /* AuthorizationWebView.swift in Sources */,
+				CB70E8A52C838FB400F9A197 /* SomethingWentWrongView.swift in Sources */,
 				CB70E8A02C8017CD00F9A197 /* ArtistList.swift in Sources */,
 				CB0B93762C771C04003A9720 /* TrackContext.swift in Sources */,
 			);

--- a/spoti-friends/src/auth/SpotifyAuth.swift
+++ b/spoti-friends/src/auth/SpotifyAuth.swift
@@ -30,65 +30,62 @@ class SpotifyAuth {
                   let queryItems = responseUrlComponents.queryItems
             else { throw URLError(.badURL) }
             
+            if (!userGrantedAuthorization(queryItems)) {
+                return .denied
+            }
+            
             if (user.isEmpty()) {
-                await populateUserWithData(user, queryItems: queryItems);
+                try await populateUserWithData(user, queryItems: queryItems);
             }
             
             if (await userExistsInDatabase(user)) {
                 storeSignedInUser(user)
                 return .granted
-            } else {
-                if (userGrantedAuthorization(queryItems)) {
-                    user.setAuthorizationStatusAs(.granted)
-                    await user.spotifyProfile?.storeProfilePictureLocally()
-                    storeSignedInUser(user)
-                    await RealmDatabase.shared.addToRealm(object: user);
-                    return .granted
-                }
-                return .denied
             }
+            
+            storeSignedInUser(user)
+            user.setAuthorizationStatusAs(.granted)
+            await user.spotifyProfile?.storeProfilePictureLocally()
+            await RealmDatabase.shared.addToRealm(object: user);
+            return .granted
         } catch {
             printError("\(error)")
-            return .unauthenticated
+            return .error
         }
     }
     
     /// Populates the `user` fields with their data.
-    @MainActor private func populateUserWithData(_ user: User, queryItems: [URLQueryItem]) async -> Void {
-        do {
-            let authorizationCode = try getAuthorizationCodeFromQueryItems(queryItems)
-            user.setAuthorizationCode(authorizationCode)
-            
-            let spotifyWebAccessToken = try await requestAccessTokenObject(authorizationCode: authorizationCode)
-            user.setSpotifyWebAccessToken(spotifyWebAccessToken!)
-            
-            let internalAPIAccessToken = try await fetchInternalAPIAccessToken(spDcCookieValue: user.spDcCookie!.value, existingToken: user.internalAPIAccessToken)
-            user.setInternalAPIAccessToken(internalAPIAccessToken)
-            
-            let spotifyProfile: SpotifyProfile = try await SpotifyAPI.shared.fetch(method: .GET,
-                                                                                   endpoint: .getCurrentUsersProfile,
-                                                                                   responseType: SpotifyProfile.self,
-                                                                                   accessToken: spotifyWebAccessToken?.access_token ?? "")
-            
-            let realm = try! await Realm()
-            
-            // A new user may already have a SpotifyProfile in the database, if an existing user has them as a friend.
-            // If so, use the existing profile to avoid creating another SpotifyProfile with a duplicate primary key.
-            let existingProfile = realm.object(ofType: SpotifyProfile.self, forPrimaryKey: spotifyProfile.spotifyId)
-            user.setSpotifyProfile(existingProfile ?? spotifyProfile)
-            user.setSpotifyId(spotifyProfile.spotifyId)
-            
-            // Same as above.
-            // The friend of a new user may already have a SpotifyProfile in the database, if an existing user is also friends with them.
-            // If so, use the existing profile to avoid creating another SpotifyProfile with a duplicate primary key.
-            let friends = try await SpotifyAPI.shared.getListOfUsersFriends(internalAPIAccessToken: internalAPIAccessToken.accessToken)
-            for friend in friends {
-                let existingProfile = realm.object(ofType: SpotifyProfile.self, forPrimaryKey: friend.spotifyId)
-                user.friends.append(existingProfile ?? friend)
-                if existingProfile == nil { await RealmDatabase.shared.addToRealm(object: friend); }
-            }
-        } catch {
-            printError("\(error)")
+    @MainActor private func populateUserWithData(_ user: User, queryItems: [URLQueryItem]) async throws -> Void {
+        let authorizationCode = try getAuthorizationCodeFromQueryItems(queryItems)
+        user.setAuthorizationCode(authorizationCode)
+        
+        let spotifyWebAccessToken = try await requestAccessTokenObject(authorizationCode: authorizationCode)
+        user.setSpotifyWebAccessToken(spotifyWebAccessToken!)
+        
+        let internalAPIAccessToken = try await fetchInternalAPIAccessToken(spDcCookieValue: user.spDcCookie!.value, existingToken: user.internalAPIAccessToken)
+        user.setInternalAPIAccessToken(internalAPIAccessToken)
+        
+        let spotifyProfile: SpotifyProfile = try await SpotifyAPI.shared.fetch(method: .GET,
+                                                                               endpoint: .getCurrentUsersProfile,
+                                                                               responseType: SpotifyProfile.self,
+                                                                               accessToken: spotifyWebAccessToken?.access_token ?? "")
+        
+        let realm = try! await Realm()
+        
+        // A new user may already have a SpotifyProfile in the database, if an existing user has them as a friend.
+        // If so, use the existing profile to avoid creating another SpotifyProfile with a duplicate primary key.
+        let existingProfile = realm.object(ofType: SpotifyProfile.self, forPrimaryKey: spotifyProfile.spotifyId)
+        user.setSpotifyProfile(existingProfile ?? spotifyProfile)
+        user.setSpotifyId(spotifyProfile.spotifyId)
+        
+        // Same as above.
+        // The friend of a new user may already have a SpotifyProfile in the database, if an existing user is also friends with them.
+        // If so, use the existing profile to avoid creating another SpotifyProfile with a duplicate primary key.
+        let friends = try await SpotifyAPI.shared.getListOfUsersFriends(internalAPIAccessToken: internalAPIAccessToken.accessToken)
+        for friend in friends {
+            let existingProfile = realm.object(ofType: SpotifyProfile.self, forPrimaryKey: friend.spotifyId)
+            user.friends.append(existingProfile ?? friend)
+            if existingProfile == nil { await RealmDatabase.shared.addToRealm(object: friend); }
         }
     }
     

--- a/spoti-friends/src/auth/views/AuthorizationDeniedView.swift
+++ b/spoti-friends/src/auth/views/AuthorizationDeniedView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// The view that is rendered when the Spotify authorization for the user failed or they denied.
 struct AuthorizationDeniedView: View {
-    @EnvironmentObject var userViewModel: AuthorizationViewModel
+    @EnvironmentObject var authorizationViewModel: AuthorizationViewModel
     
     var body: some View {
         VStack {
@@ -34,6 +34,7 @@ struct AuthorizationDeniedView: View {
             // Back to sign in button
             Spacer()
             BackToSignInButton()
+                .environmentObject(authorizationViewModel)
             Spacer()
             
         }
@@ -63,4 +64,5 @@ struct BackToSignInButton: View {
 
 #Preview {
     AuthorizationDeniedView()
+        .environmentObject(AuthorizationViewModel())
 }

--- a/spoti-friends/src/common/models/User/User.swift
+++ b/spoti-friends/src/common/models/User/User.swift
@@ -157,12 +157,12 @@ class User: Object {
 /// `granted` when the user has granted authorization and can use the application normally.
 ///
 /// `denied` when the user has denied authorization and will not be able to use the application.
+///
+/// `error` when something went wrong in authorizing the user and the user will not be able to use the application.
 enum AuthorizationStatus: String, PersistableEnum {
-    /// The user has not granted nor denied authorization and will need to make a choice.
     case unauthenticated
-    /// The user has granted authorization and can use the application normally.
     case granted
-    /// The user has denied authorization and will not be able to use the application.
     case denied
+    case error
 }
 

--- a/spoti-friends/src/common/views/AuthenticatedView.swift
+++ b/spoti-friends/src/common/views/AuthenticatedView.swift
@@ -23,7 +23,7 @@ struct AuthenticatedView: View {
                 Label("Friend Activity", systemImage: "figure.socialdance")
             }
             .environmentObject(friendActivityViewModel)
-            ProfileView(profile: friendActivityViewModel.user.spotifyProfile!).tabItem {
+            ProfileView(profile: friendActivityViewModel.user.spotifyProfile ?? SpotifyProfile()).tabItem {
                 Label("My Profile", systemImage: "person")
             }
             .environmentObject(authorizationViewModel)

--- a/spoti-friends/src/common/views/RootView.swift
+++ b/spoti-friends/src/common/views/RootView.swift
@@ -3,32 +3,42 @@ import RealmSwift
 
 /// The view that is rendered when the app opens, depending on the user's authorization status.
 ///
-/// If the user granted authorization, render the `FriendActivityView`.
+/// If the user has not completed authorization, render the `UnauthenticatedView`.
 ///
-/// If the user denied authorization, render the `DeniedView`.
+/// If the user granted authorization, render the `AuthenticatedView`.
 ///
-/// If the user has not completed authorization, render the `SignInView`.
+/// If the user denied authorization, render the `AuthorizationDeniedView`.
 struct RootView: View {
     @EnvironmentObject private var authorizationViewModel: AuthorizationViewModel
     @State private var authorizationStatus: AuthorizationStatus = .unauthenticated
+    @State private var showErrorView: Bool = false
     
     var body: some View {
         // Navigate to the appropriate view depending on the user's authorization status
         NavigationStack {
-            switch authorizationStatus {
-            case .unauthenticated:
-                UnauthenticatedView()
-            case .granted:
-                AuthenticatedView()
-                    .environmentObject(authorizationViewModel)
-            case .denied:
-                AuthorizationDeniedView()
+            VStack {
+                // Main content based on authorization status
+                switch authorizationStatus {
+                case .unauthenticated, .error:
+                    UnauthenticatedView()
+                case .granted:
+                    AuthenticatedView()
+                        .environmentObject(authorizationViewModel)
+                case .denied:
+                    AuthorizationDeniedView()
+                }
+            }
+            .navigationDestination(isPresented: $showErrorView) {
+                SomethingWentWrongView()
             }
         }
         // The onReceive is called when the `authorizationViewModel.authorizationStatus` variable
         // is changed.
-        .onReceive(authorizationViewModel.$authorizationStatus, perform: { _ in
-            self.authorizationStatus = self.authorizationViewModel.authorizationStatus
+        .onReceive(authorizationViewModel.$authorizationStatus, perform: { newStatus in
+            self.authorizationStatus = newStatus
+            if newStatus == .error {
+                self.showErrorView = true
+            }
         })
     }
 }

--- a/spoti-friends/src/common/views/errors/SomethingWentWrongView.swift
+++ b/spoti-friends/src/common/views/errors/SomethingWentWrongView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// A View that renders a generic error message stating that something went wrong.
+struct SomethingWentWrongView: View {
+    var body: some View {
+        VStack {
+            Spacer()
+            
+            // Error page title
+            Text("Oops...")
+                .foregroundStyle(Color.PresetColour.whitePrimary)
+                .font(.title)
+                .fontWeight(.bold)
+            
+            // Error image
+            Text("☹️")
+                .foregroundStyle(.white)
+                .font(.system(size: 180))
+                .padding(.vertical)
+            
+            // Explanation text
+                Text("Something went wrong.\n\n Please retry or come back later. If the issue persists, consider reaching out at friends.fm.app@gmail.com")
+            .foregroundStyle(Color.PresetColour.whitePrimary)
+            .multilineTextAlignment(.center)
+            
+            Spacer()
+            Spacer()
+        }
+        .padding()
+        .frame(maxWidth: /*@START_MENU_TOKEN@*/.infinity/*@END_MENU_TOKEN@*/, maxHeight: .infinity)
+        .background(backgroundGradient)
+    }
+}
+
+#Preview {
+    SomethingWentWrongView()
+}

--- a/spoti-friends/src/spotify/spotifyAPI/SpotifyAPI.swift
+++ b/spoti-friends/src/spotify/spotifyAPI/SpotifyAPI.swift
@@ -19,7 +19,7 @@ class SpotifyAPI {
         let request = try createRequestTo(endpoint: endpoint, accessToken: accessToken,
                                           method: method, queryParams: queryParams)
         let (data, response) = try await URLSession.shared.data(for: request)
-        if (requestFailed(response as! HTTPURLResponse)) { try throwSpotifyAPIError(response as! HTTPURLResponse) }
+        if (requestFailed(response as! HTTPURLResponse)) { throw try throwSpotifyAPIError(response as! HTTPURLResponse) }
         let decodedResponse = try JSONDecoder().decode(T.self, from: data)
         return decodedResponse
     }
@@ -45,7 +45,7 @@ class SpotifyAPI {
         var request = URLRequest(url: endpointURL)
         request.setValue("Bearer \(internalAPIAccessToken)", forHTTPHeaderField: "Authorization")
         let (data, response) = try await URLSession.shared.data(for: request)
-        if (requestFailed(response as! HTTPURLResponse)) { throw SpotifyAPIError.unsuccessfulRequest }
+        if (requestFailed(response as! HTTPURLResponse)) { throw try throwSpotifyAPIError(response as! HTTPURLResponse) }
         return data
     }
 }

--- a/spoti-friends/src/spotify/spotifyAPI/utils/SpotifyAPIError.swift
+++ b/spoti-friends/src/spotify/spotifyAPI/utils/SpotifyAPIError.swift
@@ -2,8 +2,8 @@ import Foundation
 
 /// Errors related to the Spotify Web API.
 enum SpotifyAPIError: Error {
-    case invalidToken
-    case unsuccessfulRequest
+    case unauthorized
+    case forbidden
     case unknown
 }
 
@@ -14,9 +14,17 @@ enum SpotifyAPIError: Error {
 ///   - response: The Spotify API response
 ///
 /// - Throws: A Spotify API error corresponding to what went wrong.
-internal func throwSpotifyAPIError(_ response: HTTPURLResponse) throws {
-    if response.statusCode == 401 {
+internal func throwSpotifyAPIError(_ response: HTTPURLResponse) throws -> SpotifyAPIError {
+    if (response.statusCode == 401) {
         printError("Unauthorized - The request requires user authentication or, if the request included authorization credentials, authorization has been refused for those credentials.")
-        throw SpotifyAPIError.invalidToken
+        throw SpotifyAPIError.unauthorized
+    }
+    else if (response.statusCode == 403) {
+        printError("Forbidden - The server understood the request, but is refusing to fulfill it.")
+        throw SpotifyAPIError.forbidden
+    }
+    else {
+        printError("Unknown Spotify API Error.")
+        throw SpotifyAPIError.unknown
     }
 }


### PR DESCRIPTION
#### Changes
- Render a generic `SomethingWentWrongView` when there is an error during authentication
  - This generic error view can be re-used across the app
- Refactored the logic in `handleResponseUrl()`