### PR TITLE
Release v1.2.1 (#37)

### DIFF
--- a/spoti-friends.xcodeproj/project.pbxproj
+++ b/spoti-friends.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		CB70E89E2C80174D00F9A197 /* TrackOrArtistListPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB70E89D2C80174D00F9A197 /* TrackOrArtistListPlaceholder.swift */; };
 		CB70E8A02C8017CD00F9A197 /* ArtistList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB70E89F2C8017CD00F9A197 /* ArtistList.swift */; };
 		CB70E8A22C816AAA00F9A197 /* OpenInSpotifyButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB70E8A12C816AAA00F9A197 /* OpenInSpotifyButton.swift */; };
+		CB70E8A52C838FB400F9A197 /* SomethingWentWrongView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB70E8A42C838FB400F9A197 /* SomethingWentWrongView.swift */; };
 		CB7C05A22C0EAB3B001A0062 /* AuthErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7C05A12C0EAB3B001A0062 /* AuthErrors.swift */; };
 		CB7C05A42C0EB4DB001A0062 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7C05A32C0EB4DB001A0062 /* Utils.swift */; };
 		CB7C05A92C0EBB25001A0062 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7C05A82C0EBB25001A0062 /* User.swift */; };
@@ -67,6 +68,10 @@
 		CB9A9ADA2C0BE2EE0073817C /* ColourExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9A9AD92C0BE2EE0073817C /* ColourExtension.swift */; };
 		CB9A9ADC2C0BEC080073817C /* FriendActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9A9ADB2C0BEC080073817C /* FriendActivityView.swift */; };
 		CB9A9AE02C0C22D70073817C /* SpotifyAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9A9ADF2C0C22D70073817C /* SpotifyAuth.swift */; };
+		CBB1A3C82C8E59BE00D3D658 /* ViewMoreButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBB1A3C72C8E59BE00D3D658 /* ViewMoreButton.swift */; };
+		CBB1A3CA2C8E5A8200D3D658 /* ViewMoreRecentTracks.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBB1A3C92C8E5A8200D3D658 /* ViewMoreRecentTracks.swift */; };
+		CBB1A3CC2C8FBD8E00D3D658 /* ViewMoreTopSongs.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBB1A3CB2C8FBD8E00D3D658 /* ViewMoreTopSongs.swift */; };
+		CBB1A3CE2C8FCAA300D3D658 /* ViewMoreTopArtists.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBB1A3CD2C8FCAA300D3D658 /* ViewMoreTopArtists.swift */; };
 		CBC75F522C3673DF00442795 /* TimeUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC75F512C3673DB00442795 /* TimeUtils.swift */; };
 		CBC75F562C36770500442795 /* ListeningActivityDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC75F552C36770500442795 /* ListeningActivityDetails.swift */; };
 		CBC75F582C37A6B200442795 /* TrackTimestampView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC75F572C37A6B200442795 /* TrackTimestampView.swift */; };
@@ -119,6 +124,7 @@
 		CB70E89D2C80174D00F9A197 /* TrackOrArtistListPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackOrArtistListPlaceholder.swift; sourceTree = "<group>"; };
 		CB70E89F2C8017CD00F9A197 /* ArtistList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistList.swift; sourceTree = "<group>"; };
 		CB70E8A12C816AAA00F9A197 /* OpenInSpotifyButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenInSpotifyButton.swift; sourceTree = "<group>"; };
+		CB70E8A42C838FB400F9A197 /* SomethingWentWrongView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SomethingWentWrongView.swift; sourceTree = "<group>"; };
 		CB7C05A12C0EAB3B001A0062 /* AuthErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthErrors.swift; sourceTree = "<group>"; };
 		CB7C05A32C0EB4DB001A0062 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		CB7C05A82C0EBB25001A0062 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
@@ -146,6 +152,10 @@
 		CB9A9AD92C0BE2EE0073817C /* ColourExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColourExtension.swift; sourceTree = "<group>"; };
 		CB9A9ADB2C0BEC080073817C /* FriendActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendActivityView.swift; sourceTree = "<group>"; };
 		CB9A9ADF2C0C22D70073817C /* SpotifyAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotifyAuth.swift; sourceTree = "<group>"; };
+		CBB1A3C72C8E59BE00D3D658 /* ViewMoreButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewMoreButton.swift; sourceTree = "<group>"; };
+		CBB1A3C92C8E5A8200D3D658 /* ViewMoreRecentTracks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewMoreRecentTracks.swift; sourceTree = "<group>"; };
+		CBB1A3CB2C8FBD8E00D3D658 /* ViewMoreTopSongs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewMoreTopSongs.swift; sourceTree = "<group>"; };
+		CBB1A3CD2C8FCAA300D3D658 /* ViewMoreTopArtists.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewMoreTopArtists.swift; sourceTree = "<group>"; };
 		CBC75F512C3673DB00442795 /* TimeUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeUtils.swift; sourceTree = "<group>"; };
 		CBC75F552C36770500442795 /* ListeningActivityDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningActivityDetails.swift; sourceTree = "<group>"; };
 		CBC75F572C37A6B200442795 /* TrackTimestampView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackTimestampView.swift; sourceTree = "<group>"; };
@@ -194,12 +204,14 @@
 		CB0854C42C155C510088E87D /* views */ = {
 			isa = PBXGroup;
 			children = (
+				CB70E8A32C838F9E00F9A197 /* errors */,
 				CB3B61802C1F83AE0088DFA1 /* AuthenticatedView.swift */,
 				CB3B617E2C1BDFB00088DFA1 /* PageTitle.swift */,
 				CB9A9AAC2C0BB13E0073817C /* RootView.swift */,
 				CB59BCCF2C30FA360061C99B /* RotatingSyncIcon.swift */,
 				CB0B93642C770C7A003A9720 /* placeholders */,
 				CB70E8A12C816AAA00F9A197 /* OpenInSpotifyButton.swift */,
+				CBB1A3C72C8E59BE00D3D658 /* ViewMoreButton.swift */,
 			);
 			path = views;
 			sourceTree = "<group>";
@@ -321,6 +333,9 @@
 				CB0B93622C72CD07003A9720 /* TrackList.swift */,
 				CB70E89D2C80174D00F9A197 /* TrackOrArtistListPlaceholder.swift */,
 				CB70E89F2C8017CD00F9A197 /* ArtistList.swift */,
+				CBB1A3C92C8E5A8200D3D658 /* ViewMoreRecentTracks.swift */,
+				CBB1A3CD2C8FCAA300D3D658 /* ViewMoreTopArtists.swift */,
+				CBB1A3CB2C8FBD8E00D3D658 /* ViewMoreTopSongs.swift */,
 			);
 			path = views;
 			sourceTree = "<group>";
@@ -390,6 +405,14 @@
 				CB875CAD2C315073001B364D /* FriendActivityViewModel.swift */,
 			);
 			path = viewModels;
+			sourceTree = "<group>";
+		};
+		CB70E8A32C838F9E00F9A197 /* errors */ = {
+			isa = PBXGroup;
+			children = (
+				CB70E8A42C838FB400F9A197 /* SomethingWentWrongView.swift */,
+			);
+			path = errors;
 			sourceTree = "<group>";
 		};
 		CB7C05A52C0EB8A2001A0062 /* utils */ = {
@@ -593,6 +616,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CB875CB72C35220C001B364D /* AlbumMock.swift in Sources */,
+				CBB1A3CA2C8E5A8200D3D658 /* ViewMoreRecentTracks.swift in Sources */,
 				CB0B93722C771BBB003A9720 /* Track.swift in Sources */,
 				CB0B93682C7711F6003A9720 /* AlbumCoverPlaceholder.swift in Sources */,
 				CB3B61812C1F83AE0088DFA1 /* AuthenticatedView.swift in Sources */,
@@ -621,12 +645,15 @@
 				CB875CB92C3524B4001B364D /* TrackMock.swift in Sources */,
 				CB7C05B32C1191BA001A0062 /* AuthorizationDeniedView.swift in Sources */,
 				CB59BCB72C2FAB890061C99B /* ProfileImage.swift in Sources */,
+				CBB1A3C82C8E59BE00D3D658 /* ViewMoreButton.swift in Sources */,
 				CB0B93702C771B47003A9720 /* SpotifyResource.swift in Sources */,
 				CB0854B82C1404710088E87D /* AuthorizationViewModel.swift in Sources */,
 				CB70E89E2C80174D00F9A197 /* TrackOrArtistListPlaceholder.swift in Sources */,
 				CB7C05AD2C0EEEA2001A0062 /* AuthorizationConstants.swift in Sources */,
 				CB0854C32C15583A0088E87D /* RealmDatabase.swift in Sources */,
 				CBC75F562C36770500442795 /* ListeningActivityDetails.swift in Sources */,
+				CBB1A3CC2C8FBD8E00D3D658 /* ViewMoreTopSongs.swift in Sources */,
+				CBB1A3CE2C8FCAA300D3D658 /* ViewMoreTopArtists.swift in Sources */,
 				CB0854C72C15723C0088E87D /* SpotifyAPI.swift in Sources */,
 				CB0B93782C771C23003A9720 /* Artist.swift in Sources */,
 				CB875CC02C352A4E001B364D /* ListeningActivityCardMock.swift in Sources */,
@@ -647,6 +674,7 @@
 				CB3724972C3B27CA004883D1 /* ProfileDetails.swift in Sources */,
 				CB0854CB2C1574FE0088E87D /* SpotifyProfile.swift in Sources */,
 				CB0854BC2C14D58E0088E87D /* AuthorizationWebView.swift in Sources */,
+				CB70E8A52C838FB400F9A197 /* SomethingWentWrongView.swift in Sources */,
 				CB70E8A02C8017CD00F9A197 /* ArtistList.swift in Sources */,
 				CB0B93762C771C04003A9720 /* TrackContext.swift in Sources */,
 			);

--- a/spoti-friends/src/auth/SpotifyAuth.swift
+++ b/spoti-friends/src/auth/SpotifyAuth.swift
@@ -30,65 +30,62 @@ class SpotifyAuth {
                   let queryItems = responseUrlComponents.queryItems
             else { throw URLError(.badURL) }
             
+            if (!userGrantedAuthorization(queryItems)) {
+                return .denied
+            }
+            
             if (user.isEmpty()) {
-                await populateUserWithData(user, queryItems: queryItems);
+                try await populateUserWithData(user, queryItems: queryItems);
             }
             
             if (await userExistsInDatabase(user)) {
                 storeSignedInUser(user)
                 return .granted
-            } else {
-                if (userGrantedAuthorization(queryItems)) {
-                    user.setAuthorizationStatusAs(.granted)
-                    await user.spotifyProfile?.storeProfilePictureLocally()
-                    storeSignedInUser(user)
-                    await RealmDatabase.shared.addToRealm(object: user);
-                    return .granted
-                }
-                return .denied
             }
+            
+            storeSignedInUser(user)
+            user.setAuthorizationStatusAs(.granted)
+            await user.spotifyProfile?.storeProfilePictureLocally()
+            await RealmDatabase.shared.addToRealm(object: user);
+            return .granted
         } catch {
             printError("\(error)")
-            return .unauthenticated
+            return .error
         }
     }
     
     /// Populates the `user` fields with their data.
-    @MainActor private func populateUserWithData(_ user: User, queryItems: [URLQueryItem]) async -> Void {
-        do {
-            let authorizationCode = try getAuthorizationCodeFromQueryItems(queryItems)
-            user.setAuthorizationCode(authorizationCode)
-            
-            let spotifyWebAccessToken = try await requestAccessTokenObject(authorizationCode: authorizationCode)
-            user.setSpotifyWebAccessToken(spotifyWebAccessToken!)
-            
-            let internalAPIAccessToken = try await fetchInternalAPIAccessToken(spDcCookieValue: user.spDcCookie!.value, existingToken: user.internalAPIAccessToken)
-            user.setInternalAPIAccessToken(internalAPIAccessToken)
-            
-            let spotifyProfile: SpotifyProfile = try await SpotifyAPI.shared.fetch(method: .GET,
-                                                                                   endpoint: .getCurrentUsersProfile,
-                                                                                   responseType: SpotifyProfile.self,
-                                                                                   accessToken: spotifyWebAccessToken?.access_token ?? "")
-            
-            let realm = try! await Realm()
-            
-            // A new user may already have a SpotifyProfile in the database, if an existing user has them as a friend.
-            // If so, use the existing profile to avoid creating another SpotifyProfile with a duplicate primary key.
-            let existingProfile = realm.object(ofType: SpotifyProfile.self, forPrimaryKey: spotifyProfile.spotifyId)
-            user.setSpotifyProfile(existingProfile ?? spotifyProfile)
-            user.setSpotifyId(spotifyProfile.spotifyId)
-            
-            // Same as above.
-            // The friend of a new user may already have a SpotifyProfile in the database, if an existing user is also friends with them.
-            // If so, use the existing profile to avoid creating another SpotifyProfile with a duplicate primary key.
-            let friends = try await SpotifyAPI.shared.getListOfUsersFriends(internalAPIAccessToken: internalAPIAccessToken.accessToken)
-            for friend in friends {
-                let existingProfile = realm.object(ofType: SpotifyProfile.self, forPrimaryKey: friend.spotifyId)
-                user.friends.append(existingProfile ?? friend)
-                if existingProfile == nil { await RealmDatabase.shared.addToRealm(object: friend); }
-            }
-        } catch {
-            printError("\(error)")
+    @MainActor private func populateUserWithData(_ user: User, queryItems: [URLQueryItem]) async throws -> Void {
+        let authorizationCode = try getAuthorizationCodeFromQueryItems(queryItems)
+        user.setAuthorizationCode(authorizationCode)
+        
+        let spotifyWebAccessToken = try await requestAccessTokenObject(authorizationCode: authorizationCode)
+        user.setSpotifyWebAccessToken(spotifyWebAccessToken!)
+        
+        let internalAPIAccessToken = try await fetchInternalAPIAccessToken(spDcCookieValue: user.spDcCookie!.value, existingToken: user.internalAPIAccessToken)
+        user.setInternalAPIAccessToken(internalAPIAccessToken)
+        
+        let spotifyProfile: SpotifyProfile = try await SpotifyAPI.shared.fetch(method: .GET,
+                                                                               endpoint: .getCurrentUsersProfile,
+                                                                               responseType: SpotifyProfile.self,
+                                                                               accessToken: spotifyWebAccessToken?.access_token ?? "")
+        
+        let realm = try! await Realm()
+        
+        // A new user may already have a SpotifyProfile in the database, if an existing user has them as a friend.
+        // If so, use the existing profile to avoid creating another SpotifyProfile with a duplicate primary key.
+        let existingProfile = realm.object(ofType: SpotifyProfile.self, forPrimaryKey: spotifyProfile.spotifyId)
+        user.setSpotifyProfile(existingProfile ?? spotifyProfile)
+        user.setSpotifyId(spotifyProfile.spotifyId)
+        
+        // Same as above.
+        // The friend of a new user may already have a SpotifyProfile in the database, if an existing user is also friends with them.
+        // If so, use the existing profile to avoid creating another SpotifyProfile with a duplicate primary key.
+        let friends = try await SpotifyAPI.shared.getListOfUsersFriends(internalAPIAccessToken: internalAPIAccessToken.accessToken)
+        for friend in friends {
+            let existingProfile = realm.object(ofType: SpotifyProfile.self, forPrimaryKey: friend.spotifyId)
+            user.friends.append(existingProfile ?? friend)
+            if existingProfile == nil { await RealmDatabase.shared.addToRealm(object: friend); }
         }
     }
     

--- a/spoti-friends/src/auth/views/AuthorizationDeniedView.swift
+++ b/spoti-friends/src/auth/views/AuthorizationDeniedView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// The view that is rendered when the Spotify authorization for the user failed or they denied.
 struct AuthorizationDeniedView: View {
-    @EnvironmentObject var userViewModel: AuthorizationViewModel
+    @EnvironmentObject var authorizationViewModel: AuthorizationViewModel
     
     var body: some View {
         VStack {
@@ -34,6 +34,7 @@ struct AuthorizationDeniedView: View {
             // Back to sign in button
             Spacer()
             BackToSignInButton()
+                .environmentObject(authorizationViewModel)
             Spacer()
             
         }
@@ -63,4 +64,5 @@ struct BackToSignInButton: View {
 
 #Preview {
     AuthorizationDeniedView()
+        .environmentObject(AuthorizationViewModel())
 }

--- a/spoti-friends/src/common/models/User/User.swift
+++ b/spoti-friends/src/common/models/User/User.swift
@@ -157,12 +157,12 @@ class User: Object {
 /// `granted` when the user has granted authorization and can use the application normally.
 ///
 /// `denied` when the user has denied authorization and will not be able to use the application.
+///
+/// `error` when something went wrong in authorizing the user and the user will not be able to use the application.
 enum AuthorizationStatus: String, PersistableEnum {
-    /// The user has not granted nor denied authorization and will need to make a choice.
     case unauthenticated
-    /// The user has granted authorization and can use the application normally.
     case granted
-    /// The user has denied authorization and will not be able to use the application.
     case denied
+    case error
 }
 

--- a/spoti-friends/src/common/realm/RealmDatabase.swift
+++ b/spoti-friends/src/common/realm/RealmDatabase.swift
@@ -5,7 +5,7 @@ import RealmSwift
 class RealmDatabase {
     static let shared: RealmDatabase = RealmDatabase()
     private let realm: Realm
-    private let schemaVersion: UInt64 = 21  // Increment this when making schema changes
+    private let schemaVersion: UInt64 = 31  // Increment this when making schema changes
     
     init() {
         // Use this configuration when opening realms

--- a/spoti-friends/src/common/utils/ColourExtension.swift
+++ b/spoti-friends/src/common/utils/ColourExtension.swift
@@ -20,7 +20,7 @@ extension Color {
         static var mainDarkGradient: Gradient {return  Gradient(colors: [Color(red: 0.12, green: 0.12, blue: 0.12), Color(red: 0.06, green: 0.06, blue: 0.06)])}
         
         static func profileViewGradient(profile: SpotifyProfile) -> LinearGradient {
-            let profileBackgroundColor = getBackgroundColorForImage(getProfilePictureFromDisk(imageName: profile.spotifyId))
+            let profileBackgroundColor = getBackgroundColorForImage(getProfilePictureFromDisk(imageName: profile.spotifyId), defaultColor: Color.PresetColour.spotifyGreen)
             return LinearGradient(
                 colors: [
                     Color(profileBackgroundColor),

--- a/spoti-friends/src/common/utils/ImageUtils.swift
+++ b/spoti-friends/src/common/utils/ImageUtils.swift
@@ -24,9 +24,9 @@ public func getAccentColorForImage(_ imageURLAsString: String) async throws -> U
 ///   - image: The image as a `UIImage`.
 ///
 /// - Returns: The the background color of the image as a `UIColor` or white as a default.
-public func getBackgroundColorForImage(_ image: UIImage?) -> UIColor {
+public func getBackgroundColorForImage(_ image: UIImage?, defaultColor: Color = Color(.white)) -> UIColor {
     let accentColor = image?.getColors()?.background
-    return accentColor ?? UIColor(.white)
+    return accentColor ?? UIColor(defaultColor)
 }
 
 /// Gets the profile picture named `imageName` from disk and returns as a `UIImage`.

--- a/spoti-friends/src/common/views/AuthenticatedView.swift
+++ b/spoti-friends/src/common/views/AuthenticatedView.swift
@@ -23,7 +23,7 @@ struct AuthenticatedView: View {
                 Label("Friend Activity", systemImage: "figure.socialdance")
             }
             .environmentObject(friendActivityViewModel)
-            ProfileView(profile: friendActivityViewModel.user.spotifyProfile!).tabItem {
+            ProfileView(profile: friendActivityViewModel.user.spotifyProfile ?? SpotifyProfile()).tabItem {
                 Label("My Profile", systemImage: "person")
             }
             .environmentObject(authorizationViewModel)

--- a/spoti-friends/src/common/views/RootView.swift
+++ b/spoti-friends/src/common/views/RootView.swift
@@ -3,32 +3,42 @@ import RealmSwift
 
 /// The view that is rendered when the app opens, depending on the user's authorization status.
 ///
-/// If the user granted authorization, render the `FriendActivityView`.
+/// If the user has not completed authorization, render the `UnauthenticatedView`.
 ///
-/// If the user denied authorization, render the `DeniedView`.
+/// If the user granted authorization, render the `AuthenticatedView`.
 ///
-/// If the user has not completed authorization, render the `SignInView`.
+/// If the user denied authorization, render the `AuthorizationDeniedView`.
 struct RootView: View {
     @EnvironmentObject private var authorizationViewModel: AuthorizationViewModel
     @State private var authorizationStatus: AuthorizationStatus = .unauthenticated
+    @State private var showErrorView: Bool = false
     
     var body: some View {
         // Navigate to the appropriate view depending on the user's authorization status
         NavigationStack {
-            switch authorizationStatus {
-            case .unauthenticated:
-                UnauthenticatedView()
-            case .granted:
-                AuthenticatedView()
-                    .environmentObject(authorizationViewModel)
-            case .denied:
-                AuthorizationDeniedView()
+            VStack {
+                // Main content based on authorization status
+                switch authorizationStatus {
+                case .unauthenticated, .error:
+                    UnauthenticatedView()
+                case .granted:
+                    AuthenticatedView()
+                        .environmentObject(authorizationViewModel)
+                case .denied:
+                    AuthorizationDeniedView()
+                }
+            }
+            .navigationDestination(isPresented: $showErrorView) {
+                SomethingWentWrongView()
             }
         }
         // The onReceive is called when the `authorizationViewModel.authorizationStatus` variable
         // is changed.
-        .onReceive(authorizationViewModel.$authorizationStatus, perform: { _ in
-            self.authorizationStatus = self.authorizationViewModel.authorizationStatus
+        .onReceive(authorizationViewModel.$authorizationStatus, perform: { newStatus in
+            self.authorizationStatus = newStatus
+            if newStatus == .error {
+                self.showErrorView = true
+            }
         })
     }
 }

--- a/spoti-friends/src/common/views/ViewMoreButton.swift
+++ b/spoti-friends/src/common/views/ViewMoreButton.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// A generic view that renders a "View more" navigation link and allows you to pass in any destination view.
+///
+/// - Parameters:
+///   - destination: The view that the user will navigate to when tapping the "View more" link.
+///
+/// The button will render with the "View more →" label and will push the passed in view..
+struct ViewMoreButton<Destination: View>: View {
+    let destination: Destination
+    var body: some View {
+        NavigationLink("View more \u{2192}") {
+            destination
+        }
+        .foregroundStyle(Color.PresetColour.whitePrimary)
+        .font(.callout)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ViewMoreButton(destination: Text("New stacked view"))
+    }
+}

--- a/spoti-friends/src/common/views/errors/SomethingWentWrongView.swift
+++ b/spoti-friends/src/common/views/errors/SomethingWentWrongView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// A View that renders a generic error message stating that something went wrong.
+struct SomethingWentWrongView: View {
+    var body: some View {
+        VStack {
+            Spacer()
+            
+            // Error page title
+            Text("Oops...")
+                .foregroundStyle(Color.PresetColour.whitePrimary)
+                .font(.title)
+                .fontWeight(.bold)
+            
+            // Error image
+            Text("☹️")
+                .foregroundStyle(.white)
+                .font(.system(size: 180))
+                .padding(.vertical)
+            
+            // Explanation text
+                Text("Something went wrong.\n\n Please retry or come back later. If the issue persists, consider reaching out at friends.fm.app@gmail.com")
+            .foregroundStyle(Color.PresetColour.whitePrimary)
+            .multilineTextAlignment(.center)
+            
+            Spacer()
+            Spacer()
+        }
+        .padding()
+        .frame(maxWidth: /*@START_MENU_TOKEN@*/.infinity/*@END_MENU_TOKEN@*/, maxHeight: .infinity)
+        .background(backgroundGradient)
+    }
+}
+
+#Preview {
+    SomethingWentWrongView()
+}

--- a/spoti-friends/src/friendActivity/viewModels/FriendActivityViewModel.swift
+++ b/spoti-friends/src/friendActivity/viewModels/FriendActivityViewModel.swift
@@ -11,8 +11,8 @@ class FriendActivityViewModel: ObservableObject {
         self.user = user
         self.friendActivites = friendActivites
         
-        let refreshInterval: TimeInterval = 60
-        Timer.publish(every: refreshInterval, on: .main, in: .common)
+        let refreshIntervalinSeconds: TimeInterval = 60
+        Timer.publish(every: refreshIntervalinSeconds, on: .main, in: .common)
             .autoconnect()
             .sink { [weak self] _ in
                 self?.refreshFriendActivity()

--- a/spoti-friends/src/profile/viewModels/ProfileViewModel.swift
+++ b/spoti-friends/src/profile/viewModels/ProfileViewModel.swift
@@ -3,8 +3,33 @@ import Foundation
 class ProfileViewModel: ObservableObject {
     @Published var user: User
     
+    // Cached values are for the logged in user only
+    private var cacheClearTimer: Timer?
+    @Published var cachedTopArtists: [Artist] = []
+    @Published var cachedTopTracks: [Track] = []
+    
     init(user: User){
         self.user = user
+        startCacheTimer()
+    }
+    
+    // Start the timer to clear cache every 10 minutes
+    private func startCacheTimer() {
+        cacheClearTimer = Timer.scheduledTimer(withTimeInterval: 600, repeats: true) { [weak self] _ in
+            self?.clearCache()
+        }
+    }
+    
+    // Clear cached top artists
+    private func clearCache() {
+        cachedTopArtists.removeAll()
+        cachedTopTracks.removeAll()
+        print("Cache cleared")
+    }
+    
+    // Function to invalidate the timer when no longer needed
+    deinit {
+        cacheClearTimer?.invalidate()
     }
     
     /// Fetches and returns the follower count for the logged in user.
@@ -39,6 +64,28 @@ class ProfileViewModel: ObservableObject {
         return -1
     }
     
+    enum ProfileItems {
+        case recentTracks
+        case topTracks
+        case topArtists
+    }
+    
+    @MainActor func viewMoreForCurrentUser(forItem: ProfileItems, timeRange: TimeRange = .oneMonth) async -> ProfileItemsResponse? {
+        let limit = 20
+        
+        switch forItem {
+        case .recentTracks:
+            let tracks = await getCurrentUsersRecentTracks(limit: limit)
+            return .tracks(tracks)
+        case .topTracks:
+            let tracks = await getCurrentUsersTopTracks(timeRange: timeRange, limit: limit)
+            return .tracks(tracks)
+        case .topArtists:
+            let artists = await getCurrentUsersTopArtists(timeRange: timeRange, limit: limit)
+            return .artists(artists)
+        }
+    }
+    
     /// Fetches and returns the current user's recent tracks.
     ///
     /// - Parameters:
@@ -69,8 +116,13 @@ class ProfileViewModel: ObservableObject {
     /// - Parameters:
     ///   - timeRange: Over what time frame the data is calculated.
     ///   - limit: The maximum number of items to return. Default: 5. Minimum: 1. Maximum: 50.
-    @MainActor func getCurrentUsersTopTracks(timeRange: GetCurrentUserTopTracksResponse.TimeRange, limit: Int)
+    @MainActor func getCurrentUsersTopTracks(timeRange: TimeRange, limit: Int)
     async -> TracksWithResponseMetadata? {
+        // The cache should only be used for the "View more" screen – hence the check for limit == 20.
+        if (!self.cachedTopTracks.isEmpty && limit == 20) {
+            return TracksWithResponseMetadata(tracks: self.cachedTopTracks, isEmpty: self.cachedTopTracks.isEmpty)
+        }
+        
         do {
             let accessToken = try await self.user.getSpotifyWebAccessToken().access_token
             let queryParams = [
@@ -83,21 +135,30 @@ class ProfileViewModel: ObservableObject {
                                                              accessToken: accessToken,
                                                              queryParams: queryParams)
             
+            // Only cache data when opening in "View more"
+            if (limit == 20) {
+                self.cachedTopTracks = response.items
+            }
             return TracksWithResponseMetadata(tracks: response.items, isEmpty: response.items.isEmpty)
         }
         catch {
             printError("\(error)")
             return nil
         }
-    }    
+    }
     
     /// Fetches and returns the current user's top artists.
     ///
     /// - Parameters:
     ///   - timeRange: Over what time frame the data is calculated.
     ///   - limit: The maximum number of items to return. Default: 5. Minimum: 1. Maximum: 50.
-    @MainActor func getCurrentUsersTopArtists(timeRange: GetCurrentUserTopArtistsResponse.TimeRange, limit: Int)
+    @MainActor func getCurrentUsersTopArtists(timeRange: TimeRange, limit: Int)
     async -> ArtistsWithResponseMetadata? {
+        // The cache should only be used for the "View more" screen – hence the check for limit == 20.
+        if (!self.cachedTopArtists.isEmpty && limit == 20) {
+            return ArtistsWithResponseMetadata(artists: self.cachedTopArtists, isEmpty: self.cachedTopArtists.isEmpty)
+        }
+        
         do {
             let accessToken = try await self.user.getSpotifyWebAccessToken().access_token
             let queryParams = [
@@ -110,6 +171,10 @@ class ProfileViewModel: ObservableObject {
                                                              accessToken: accessToken,
                                                              queryParams: queryParams)
             
+            // Only cache data when opening in "View more"
+            if (limit == 20) {
+                self.cachedTopArtists = response.items
+            }
             return ArtistsWithResponseMetadata(artists: response.items, isEmpty: response.items.isEmpty)
         }
         catch {
@@ -152,14 +217,19 @@ extension ProfileViewModel {
         }
     }
     
+    enum ProfileItemsResponse {
+        case tracks(TracksWithResponseMetadata?)
+        case artists(ArtistsWithResponseMetadata?)
+    }
+    
+    /// The valid values for the `time_range` parameter for the `topTracks` and `topArtists` API endpoints.
+    enum TimeRange: String {
+        case oneMonth = "short_term"
+        case sixMonths = "medium_term"
+        case oneYear = "long_term"
+    }
+    
     public class GetCurrentUserTopTracksResponse: Decodable {
-        /// The valid values for the `time_range` parameter.
-        enum TimeRange: String {
-            case oneMonth = "short_term"
-            case sixMonths = "medium_term"
-            case oneYear = "long_term"
-        }
-        
         let items: [Track]
     }
     
@@ -186,13 +256,6 @@ extension ProfileViewModel {
     }
     
     public class GetCurrentUserTopArtistsResponse: Decodable {
-        /// The valid values for the `time_range` parameter.
-        enum TimeRange: String {
-            case oneMonth = "short_term"
-            case sixMonths = "medium_term"
-            case oneYear = "long_term"
-        }
-        
         let items: [Artist]
     }
     

--- a/spoti-friends/src/profile/views/ArtistList.swift
+++ b/spoti-friends/src/profile/views/ArtistList.swift
@@ -8,6 +8,13 @@ import SwiftUI
 /// - Returns: A View that renders a list of artists.
 struct ArtistList: View {
     let artists: [Artist]
+    let showItemNumbers: Bool
+    
+    init(artists: [Artist], showItemNumbers: Bool = false) {
+        self.artists = artists
+        self.showItemNumbers = showItemNumbers
+    }
+    
     var body: some View {
         // Render loading placeholders while waiting for data
         if (artists.isEmpty) {
@@ -17,9 +24,18 @@ struct ArtistList: View {
         // Actual list once data is available
         else {
             VStack (alignment: .leading) {
-                ForEach(artists) { artist in
+                ForEach(artists.indices, id: \.self) { index in
+                    let artist = artists[index]
+                    
                     Link(destination: URL(string: artist.spotifyUri)!) {
                         HStack {
+                            if (showItemNumbers) {
+                                Text(String(index + 1))
+                                    .foregroundStyle(Color.PresetColour.whiteSecondary)
+                                    .font(.footnote)
+                                    .frame(width: 20)
+                                    .padding(.trailing, 2)
+                            }
                             ImageWithSpecs(imageUrl: artist.image, width: 36, height: 36, cornerRadius: 2)
                             VStack (alignment: .leading) {
                                 // Artist name

--- a/spoti-friends/src/profile/views/ProfileView.swift
+++ b/spoti-friends/src/profile/views/ProfileView.swift
@@ -29,101 +29,103 @@ struct ProfileView: View {
     }
     
     var body: some View {
-        GeometryReader { reader in
-            ScrollView {
-                VStack (alignment: .leading, spacing: 34) {
-                    // Profile Details
-                    ProfileDetails(profile: profile)
-                        .environmentObject(profileViewModel)
-                        .environmentObject(friendActivityViewModel)
-                    
-                    // Recent Tracks
-                    VStack (alignment: .leading) {
-                        Text("Recent Songs")
-                            .font(.body)
-                            .foregroundStyle(Color.PresetColour.whitePrimary)
+        NavigationStack {
+            GeometryReader { reader in
+                ScrollView {
+                    VStack (alignment: .leading, spacing: 34) {
+                        // Profile Details
+                        ProfileDetails(profile: profile)
+                            .environmentObject(profileViewModel)
+                            .environmentObject(friendActivityViewModel)
                         
-                        if (recentTracks.isEmpty) {
-                            Text("It's oddly quiet here...")
-                                .font(.callout)
-                                .foregroundStyle(Color.PresetColour.whiteSecondary)
-                                .padding(.vertical, 4)
+                        // Recent Tracks
+                        VStack (alignment: .leading) {
+                            Text("Recent Songs")
+                                .font(.body)
+                                .foregroundStyle(Color.PresetColour.whitePrimary)
+                            
+                            if recentTracks.isEmpty {
+                                Text("It's oddly quiet here...")
+                                    .font(.callout)
+                                    .foregroundStyle(Color.PresetColour.whiteSecondary)
+                                    .padding(.vertical, 4)
+                            } else {
+                                TrackList(tracks: recentTracks.tracks)
+                                ViewMoreButton(destination: ViewMoreRecentTracks(profile: profile)
+                                    .environmentObject(profileViewModel))
+                                .padding(.top, 4)
+                            }
                         }
-                        else {
-                            TrackList(tracks: recentTracks.tracks)
-                        }
-                    }
-                    
-                    // Top Tracks
-                    VStack (alignment: .leading) {
-                        Text("Top Songs")
-                            .font(.body)
-                            .foregroundStyle(Color.PresetColour.whitePrimary)
-                        Text("From this month")
-                            .font(.footnote)
-                            .foregroundStyle(Color.PresetColour.whiteSecondary)
                         
-                        if (topTracks.isEmpty) {
-                            Text("Not enough listening data this month.")
-                                .font(.callout)
+                        // Top Tracks
+                        VStack (alignment: .leading) {
+                            Text("Top Songs")
+                                .font(.body)
+                                .foregroundStyle(Color.PresetColour.whitePrimary)
+                            Text("From this month")
+                                .font(.footnote)
                                 .foregroundStyle(Color.PresetColour.whiteSecondary)
-                                .padding(.vertical, 4)
+                            
+                            if topTracks.isEmpty {
+                                Text("Not enough listening data this month.")
+                                    .font(.callout)
+                                    .foregroundStyle(Color.PresetColour.whiteSecondary)
+                                    .padding(.vertical, 4)
+                            } else {
+                                TrackList(tracks: topTracks.tracks)
+                                ViewMoreButton(destination: ViewMoreTopSongs(profile: profile)
+                                    .environmentObject(profileViewModel))
+                                .padding(.top, 4)
+                            }
                         }
-                        else {
-                            TrackList(tracks: topTracks.tracks)
-                        }
-                    }
-                    
-                    // Top Artists
-                    VStack (alignment: .leading) {
-                        Text("Top Artists")
-                            .font(.body)
-                            .foregroundStyle(Color.PresetColour.whitePrimary)
-                        Text("From this month")
-                            .font(.footnote)
-                            .foregroundStyle(Color.PresetColour.whiteSecondary)
                         
-                        if (topArtists.isEmpty) {
-                            Text("Not enough listening data this month.")
-                                .font(.callout)
+                        // Top Artists
+                        VStack (alignment: .leading) {
+                            Text("Top Artists")
+                                .font(.body)
+                                .foregroundStyle(Color.PresetColour.whitePrimary)
+                            Text("From this month")
+                                .font(.footnote)
                                 .foregroundStyle(Color.PresetColour.whiteSecondary)
-                                .padding(.vertical, 4)
+                            
+                            if topArtists.isEmpty {
+                                Text("Not enough listening data this month.")
+                                    .font(.callout)
+                                    .foregroundStyle(Color.PresetColour.whiteSecondary)
+                                    .padding(.vertical, 4)
+                            } else {
+                                ArtistList(artists: topArtists.artists)
+                                ViewMoreButton(destination: ViewMoreTopArtists(profile: profile)
+                                    .environmentObject(profileViewModel))
+                                .padding(.top, 4)
+                            }
                         }
-                        else {
-                            ArtistList(artists: topArtists.artists)
-                        }
+                        Spacer()
                     }
-                    Spacer()
+                    .frame(minHeight: reader.size.height)
+                    .padding(.horizontal, 20)
+                    
+                    // Logout Button
+                    LogoutButton()
+                        .padding(.bottom, 10)
                 }
-                .frame(minHeight: reader.size.height)
-                .padding(.horizontal, 20)
-                
-                // TODO: This needs to be moved to a view for only the logged in profile
-                // or keep it here but conditionally render it.
-                LogoutButton()
-                    .padding(.bottom, 10)
-            }
-            .padding(.top)
-            .background(Color.PresetGradient.profileViewGradient(profile: profile))
-            .onAppear {
-                profileViewModel.user = authorizationViewModel.user
-                
-                Task {
-                    // NOTE: Comment out these lines to fix SwiftUI Previews
-                    recentTracks = await profileViewModel.getCurrentUsersRecentTracks(limit: 5)
-                    ?? ProfileViewModel.TracksWithResponseMetadata(tracks: [])
+                .padding(.top)
+                .background(Color.PresetGradient.profileViewGradient(profile: profile))
+                .onAppear {
+                    profileViewModel.user = authorizationViewModel.user
                     
-                    topTracks = await profileViewModel.getCurrentUsersTopTracks(timeRange: .oneMonth, limit: 5)
-                    ?? ProfileViewModel.TracksWithResponseMetadata(tracks: [])
-                    
-                    topArtists = await profileViewModel.getCurrentUsersTopArtists(timeRange: .oneMonth, limit: 5)
-                    ?? ProfileViewModel.ArtistsWithResponseMetadata(artists: [])
+                    Task {
+                        // Comment out these lines for SwiftUI Previews
+                        recentTracks = await profileViewModel.getCurrentUsersRecentTracks(limit: 5) ?? ProfileViewModel.TracksWithResponseMetadata(tracks: [])
+                        topTracks = await profileViewModel.getCurrentUsersTopTracks(timeRange: .oneMonth, limit: 5) ?? ProfileViewModel.TracksWithResponseMetadata(tracks: [])
+                        topArtists = await profileViewModel.getCurrentUsersTopArtists(timeRange: .oneMonth, limit: 5) ?? ProfileViewModel.ArtistsWithResponseMetadata(artists: [])
+                    }
                 }
             }
         }
     }
     
-    /// The view for the log out button.
+    // Logout button
     struct LogoutButton: View {
         @EnvironmentObject private var authorizationViewModel: AuthorizationViewModel
         

--- a/spoti-friends/src/profile/views/TrackList.swift
+++ b/spoti-friends/src/profile/views/TrackList.swift
@@ -8,6 +8,13 @@ import SwiftUI
 /// - Returns: A View that renders a list of tracks.
 struct TrackList: View {
     let tracks: [Track]
+    let showItemNumbers: Bool
+    
+    init(tracks: [Track], showItemNumbers: Bool = false) {
+        self.tracks = tracks
+        self.showItemNumbers = showItemNumbers
+    }
+    
     var body: some View {
         // Render loading placeholders while waiting for data
         if (tracks.isEmpty) {
@@ -17,9 +24,18 @@ struct TrackList: View {
         // Actual list once data is available
         else {
             VStack (alignment: .leading) {
-                ForEach(tracks) { track in
+                ForEach(tracks.indices, id: \.self) { index in
+                    let track = tracks[index]
+                    
                     Link(destination: URL(string: track.spotifyUri)!) {
                         HStack {
+                            if (showItemNumbers) {
+                                Text(String(index + 1))
+                                    .foregroundStyle(Color.PresetColour.whiteSecondary)
+                                    .font(.footnote)
+                                    .frame(width: 20)
+                                    .padding(.trailing, 2)
+                            }
                             ImageWithSpecs(imageUrl: track.album?.image ?? "", width: 36, height: 36, cornerRadius: 2)
                             
                             VStack (alignment: .leading) {
@@ -42,6 +58,7 @@ struct TrackList: View {
                                         .foregroundStyle(Color.PresetColour.whiteSecondary)
                                     }
                                 }
+                                .lineLimit(1)
                             }
                             
                             Spacer() // To left align the content

--- a/spoti-friends/src/profile/views/ViewMoreRecentTracks.swift
+++ b/spoti-friends/src/profile/views/ViewMoreRecentTracks.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+/// A SwiftUI view that displays a user's recent songs.
+/// This view is part of a navigation stack and shows a scrollable list of tracks.
+///
+/// - Parameters:
+///   - profile: The Spotify Profile to show the data for.
+///
+struct ViewMoreRecentTracks: View {
+    let profile: SpotifyProfile
+    @State private var recentTracks: ProfileViewModel.TracksWithResponseMetadata
+    @EnvironmentObject private var profileViewModel: ProfileViewModel
+    
+    init(profile: SpotifyProfile, recentTracks: [Track] = []) {
+        self.profile = profile
+        self.recentTracks = ProfileViewModel.TracksWithResponseMetadata(tracks: recentTracks)
+    }
+    
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading) {
+                Text("Recent Songs")
+                    .foregroundStyle(Color.PresetColour.whitePrimary)
+                    .font(.title2)
+                TrackList(tracks: recentTracks.tracks)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 20)
+        }
+        .background(Color.PresetColour.darkgrey)
+        .toolbarBackground(Color.PresetColour.darkgrey, for: .navigationBar)
+        .onAppear {
+            Task {
+                let response = await profileViewModel.viewMoreForCurrentUser(forItem: .recentTracks)
+                switch response {
+                case .tracks(let tracksWithMetadata):
+                    recentTracks = tracksWithMetadata ?? ProfileViewModel.TracksWithResponseMetadata(tracks: [])
+                default:
+                    // It should not end up in this case.
+                    recentTracks = ProfileViewModel.TracksWithResponseMetadata(tracks: [])
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        let user = UserMock.userJimHalpert
+        let profile = SpotifyProfileMock.jimHalpert
+        let recentTracks = [
+            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+            TrackMock.iRememberEverything, TrackMock.luxury
+        ]
+        ViewMoreRecentTracks(profile: profile, recentTracks: recentTracks)
+            .environmentObject(ProfileViewModel(user: user))
+    }
+}

--- a/spoti-friends/src/profile/views/ViewMoreTopArtists.swift
+++ b/spoti-friends/src/profile/views/ViewMoreTopArtists.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+/// A SwiftUI view that displays a user's top artists.
+/// This view is part of a navigation stack and shows a scrollable list of artists.
+///
+/// - Parameters:
+///   - profile: The Spotify Profile to show the data for.
+///
+struct ViewMoreTopArtists: View {
+    let profile: SpotifyProfile
+    @State private var topArtists: ProfileViewModel.ArtistsWithResponseMetadata
+    @EnvironmentObject private var profileViewModel: ProfileViewModel
+    
+    init(profile: SpotifyProfile, topArtists: [Artist] = []) {
+        self.profile = profile
+        self.topArtists = ProfileViewModel.ArtistsWithResponseMetadata(artists: topArtists)
+    }
+    
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading) {
+                Text("Top Artists")
+                    .foregroundStyle(Color.PresetColour.whitePrimary)
+                    .font(.title2)
+                ArtistList(artists: topArtists.artists, showItemNumbers: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 20)
+        }
+        .background(Color.PresetColour.darkgrey)
+        .toolbarBackground(Color.PresetColour.darkgrey, for: .navigationBar)
+        .onAppear {
+            Task {
+                let response = await profileViewModel.viewMoreForCurrentUser(forItem: .topArtists)
+                switch response {
+                case .artists(let artistsWithMetadata):
+                    topArtists = artistsWithMetadata ?? ProfileViewModel.ArtistsWithResponseMetadata(artists: [])
+                default:
+                    // It should not end up in this case.
+                    topArtists = ProfileViewModel.ArtistsWithResponseMetadata(artists: [])
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        let user = UserMock.userJimHalpert
+        let profile = SpotifyProfileMock.jimHalpert
+        let topArtists = [
+            ArtistMock.jonBellion, ArtistMock.kaceyMusgraves, ArtistMock.oliviaRodrigo, ArtistMock.zachBryan,
+            ArtistMock.jonBellion, ArtistMock.kaceyMusgraves, ArtistMock.oliviaRodrigo, ArtistMock.zachBryan,
+            ArtistMock.jonBellion, ArtistMock.kaceyMusgraves, ArtistMock.oliviaRodrigo, ArtistMock.zachBryan,
+            ArtistMock.jonBellion, ArtistMock.kaceyMusgraves, ArtistMock.oliviaRodrigo, ArtistMock.zachBryan,
+            ArtistMock.jonBellion, ArtistMock.kaceyMusgraves, ArtistMock.oliviaRodrigo, ArtistMock.zachBryan
+        ]
+        ViewMoreTopArtists(profile: profile, topArtists: topArtists)
+            .environmentObject(ProfileViewModel(user: user))
+    }
+}

--- a/spoti-friends/src/profile/views/ViewMoreTopSongs.swift
+++ b/spoti-friends/src/profile/views/ViewMoreTopSongs.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+/// A SwiftUI view that displays a user's top songs.
+/// This view is part of a navigation stack and shows a scrollable list of tracks.
+///
+/// - Parameters:
+///   - profile: The Spotify Profile to show the data for.
+///
+struct ViewMoreTopSongs: View {
+    let profile: SpotifyProfile
+    @State private var topTracks: ProfileViewModel.TracksWithResponseMetadata
+    @EnvironmentObject private var profileViewModel: ProfileViewModel
+    
+    init(profile: SpotifyProfile, topTracks: [Track] = []) {
+        self.profile = profile
+        self.topTracks = ProfileViewModel.TracksWithResponseMetadata(tracks: topTracks)
+    }
+    
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading) {
+                Text("Top Songs")
+                    .foregroundStyle(Color.PresetColour.whitePrimary)
+                    .font(.title2)
+                TrackList(tracks: topTracks.tracks, showItemNumbers: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 20)
+        }
+        .background(Color.PresetColour.darkgrey)
+        .toolbarBackground(Color.PresetColour.darkgrey, for: .navigationBar)
+        .onAppear {
+            Task {
+                let response = await profileViewModel.viewMoreForCurrentUser(forItem: .topTracks)
+                switch response {
+                case .tracks(let tracksWithMetadata):
+                    topTracks = tracksWithMetadata ?? ProfileViewModel.TracksWithResponseMetadata(tracks: [])
+                default:
+                    // It should not end up in this case.
+                    topTracks = ProfileViewModel.TracksWithResponseMetadata(tracks: [])
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        let user = UserMock.userJimHalpert
+        let profile = SpotifyProfileMock.jimHalpert
+        let topTracks = [
+            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+            TrackMock.iRememberEverything, TrackMock.luxury
+        ]
+        ViewMoreTopSongs(profile: profile, topTracks: topTracks)
+            .environmentObject(ProfileViewModel(user: user))
+    }
+}

--- a/spoti-friends/src/spotify/spotifyAPI/SpotifyAPI.swift
+++ b/spoti-friends/src/spotify/spotifyAPI/SpotifyAPI.swift
@@ -19,7 +19,7 @@ class SpotifyAPI {
         let request = try createRequestTo(endpoint: endpoint, accessToken: accessToken,
                                           method: method, queryParams: queryParams)
         let (data, response) = try await URLSession.shared.data(for: request)
-        if (requestFailed(response as! HTTPURLResponse)) { try throwSpotifyAPIError(response as! HTTPURLResponse) }
+        if (requestFailed(response as! HTTPURLResponse)) { throw try throwSpotifyAPIError(response as! HTTPURLResponse) }
         let decodedResponse = try JSONDecoder().decode(T.self, from: data)
         return decodedResponse
     }
@@ -45,7 +45,7 @@ class SpotifyAPI {
         var request = URLRequest(url: endpointURL)
         request.setValue("Bearer \(internalAPIAccessToken)", forHTTPHeaderField: "Authorization")
         let (data, response) = try await URLSession.shared.data(for: request)
-        if (requestFailed(response as! HTTPURLResponse)) { throw SpotifyAPIError.unsuccessfulRequest }
+        if (requestFailed(response as! HTTPURLResponse)) { throw try throwSpotifyAPIError(response as! HTTPURLResponse) }
         return data
     }
 }

--- a/spoti-friends/src/spotify/spotifyAPI/utils/SpotifyAPIError.swift
+++ b/spoti-friends/src/spotify/spotifyAPI/utils/SpotifyAPIError.swift
@@ -2,8 +2,8 @@ import Foundation
 
 /// Errors related to the Spotify Web API.
 enum SpotifyAPIError: Error {
-    case invalidToken
-    case unsuccessfulRequest
+    case unauthorized
+    case forbidden
     case unknown
 }
 
@@ -14,9 +14,17 @@ enum SpotifyAPIError: Error {
 ///   - response: The Spotify API response
 ///
 /// - Throws: A Spotify API error corresponding to what went wrong.
-internal func throwSpotifyAPIError(_ response: HTTPURLResponse) throws {
-    if response.statusCode == 401 {
+internal func throwSpotifyAPIError(_ response: HTTPURLResponse) throws -> SpotifyAPIError {
+    if (response.statusCode == 401) {
         printError("Unauthorized - The request requires user authentication or, if the request included authorization credentials, authorization has been refused for those credentials.")
-        throw SpotifyAPIError.invalidToken
+        throw SpotifyAPIError.unauthorized
+    }
+    else if (response.statusCode == 403) {
+        printError("Forbidden - The server understood the request, but is refusing to fulfill it.")
+        throw SpotifyAPIError.forbidden
+    }
+    else {
+        printError("Unknown Spotify API Error.")
+        throw SpotifyAPIError.unknown
     }
 }


### PR DESCRIPTION
* Fix duplicate spotify profiles bug (#24)

* Added versioning (#26)

* Display users top artists (#27)

* Fetched top artists and displayed them

* Make top songs and artists redirect to spotify resource

* Added encryption compliance and increased version to 1.1.0 (#28)

* Revert "Added encryption compliance and increased version to 1.1.0 (#… (#29)

* Revert "Added encryption compliance and increased version to 1.1.0 (#28)"

This reverts commit b016dc190f68844882f70a1f4234c07c8e2e7120.

* Added encryption compliance and increased version to 1.1.0

* Prefixed semantic versioning with 'v'

* Removed prefixed semantic versioning with 'v' since XCode does not allow it

* Display "Open in Spotify" button in Profile View (#31)

* Display users recent songs (#32)

* Only render up to two genres for artists

* Fetches and displays the user's recent tracks

* Increased version to v1.2.0 and updated some documentation (#33)

* More graceful error handling when something goes wrong during authentication (#35)

* View more profile data (#36)

- Added "View more" buttons to each profile item - Clicking the button will fetch and render the first 20 items instead of 5
- Added caching to the view more views
- Updated ProfileView default background gradient colour to Spotify Green

#### Changes
- 
