### PR TITLE
FM-106 Migrate Profile Feature

### DIFF
--- a/spoti-friends/src/auth/SpotifyAuth.swift
+++ b/spoti-friends/src/auth/SpotifyAuth.swift
@@ -65,7 +65,7 @@ class SpotifyAuth {
             .fetch(method: .GET,
                    endpoint: .getCurrentUsersProfile,
                    responseType: SpotifyProfile.self,
-                   accessToken: spotifyWebAccessToken.access_token)
+                   accessToken: spotifyWebAccessToken.getAccessToken())
 
         let friends = try await SpotifyAPI.shared
             .getListOfUsersFriends(internalAPIAccessToken: internalAPIAccessToken.getAccessToken())
@@ -79,17 +79,6 @@ class SpotifyAuth {
                             authorizationStatus: .granted,
                             spDcCookie: spDcCookie)
     }
-    
-//    /// Returns `true` if the `user` already exists in the database and `false` otherwise.
-//    private func userExistsInDatabase(_ user: User) async -> Bool {
-//        var userExists: Bool = false
-//        DispatchQueue.main.sync {
-//            let realm = RealmDatabase.shared.getRealmInstance()
-//            userExists = realm.objects(User.self).where { $0.spotifyId == user.spotifyId }.count != 0
-//        }
-//        
-//        return userExists
-//    }
     
     /// Stores the user as the signed in user in `UserDefaults`.
     private func storeSignedInUser(_ user: User) -> Void {
@@ -168,23 +157,25 @@ class SpotifyAuth {
         return request
     }
     
-//    /// Requests abd returns a refreshed Spotify Web Access Token object.
-//    ///
-//    /// - Parameters:
-//    ///   - refreshToken: The refresh token returned from the authoriztion token request.
-//    ///
-//    /// - Returns: A new `SpotifyWebAccessToken`.
-//    public func refreshAccessToken(refreshToken: String) async throws -> SpotifyWebAccessToken {
-//        do {
-//            let request = try constructRefreshAccessTokenRequest(refreshToken: refreshToken)
-//            let (data, _) = try await URLSession.shared.data(for: request)
-//            let accessToken = try JSONDecoder().decode(SpotifyWebAccessToken.self, from: data)
-//            return accessToken
-//        } catch {
-//            printError("\(error)")
-//            throw error
-//        }
-//    }
+    /// Requests and returns a refreshed Spotify Web Access Token object.
+    ///
+    /// - Parameters:
+    ///   - refreshToken: The refresh token returned from the authoriztion token request.
+    ///
+    /// - Returns: A new `SpotifyWebAccessToken`.
+    public func refreshAccessToken(refreshToken: String) async throws -> SpotifyWebAccessToken {
+        do {
+            let request = try constructRefreshAccessTokenRequest(refreshToken: refreshToken)
+            let (data, _) = try await URLSession.shared.data(for: request)
+            let responseString = String(data: data, encoding: .utf8)
+            print("Response Data: \(responseString)")
+            let accessToken = try JSONDecoder().decode(SpotifyWebAccessToken.self, from: data)
+            return accessToken
+        } catch {
+            printError("When trying to refresh Spotify Web Access Token: \(error)")
+            throw error
+        }
+    }
     
     /// Fetches and returns the Spotify Web Player Access Token needed for calling the `/buddylist` internal API endpoint.
     /// This is different than the Access Token for the Web API.

--- a/spoti-friends/src/auth/viewModels/AuthorizationViewModel.swift
+++ b/spoti-friends/src/auth/viewModels/AuthorizationViewModel.swift
@@ -37,7 +37,7 @@ class AuthorizationViewModel: ObservableObject {
             
             let existingUser = try await UserServiceManager.shared.getUserFromDB(withSpotifyId: signedInUserId)
             self.user = existingUser
-            self.authorizationStatus = existingUser?.authorizationStatus ?? .unauthenticated
+            self.authorizationStatus = existingUser?.getAuthorizationStatus() ?? .unauthenticated
             self.isFetchingUser = false
         } catch {
             self.user = nil

--- a/spoti-friends/src/common/models/Types.swift
+++ b/spoti-friends/src/common/models/Types.swift
@@ -11,12 +11,21 @@ import AppwriteModels
 ///   - refresh_token: The refresh token to be used to obtain new access tokens.
 ///   - accessTokenExpirationTimestampMs: Timestamp for when the access token expires.
 class SpotifyWebAccessToken: Codable {
-    var access_token: String
-    var token_type: String
-    var scope: String
-    var expires_in: Int
-    var refresh_token: String
-    var accessTokenExpirationTimestampMs: Int
+    private var access_token: String
+    private var token_type: String
+    private var scope: String
+    private var expires_in: Int
+    private var refresh_token: String
+    private var accessTokenExpirationTimestampMs: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case access_token
+        case token_type
+        case scope
+        case expires_in
+        case refresh_token
+        case accessTokenExpirationTimestampMs
+    }
     
     init(access_token: String, token_type: String, scope: String, expires_in: Int,
          refresh_token: String, accessTokenExpirationTimestampMs: Double) {
@@ -35,13 +44,25 @@ class SpotifyWebAccessToken: Codable {
         self.scope = try container.decode(String.self, forKey: .scope)
         self.expires_in = try container.decode(Int.self, forKey: .expires_in)
         self.refresh_token = try container.decode(String.self, forKey: .refresh_token)
-        self.accessTokenExpirationTimestampMs = Int(SpotifyWebAccessToken.getExpiryTimestamp())
+        self.accessTokenExpirationTimestampMs = try container.decodeIfPresent(Int.self, forKey: .accessTokenExpirationTimestampMs) ?? Int(SpotifyWebAccessToken.calculateExpiryTimestamp())
     }
     
-    static public func getExpiryTimestamp() -> TimeInterval {
+    static public func calculateExpiryTimestamp() -> TimeInterval {
         let currentDate = Date()
         let oneHourFromNow = currentDate.addingTimeInterval(3600)
         return oneHourFromNow.timeIntervalSince1970 * 1000
+    }
+    
+    public func getAccessToken() -> String {
+        return self.access_token
+    }
+    
+    public func getRefreshToken() -> String {
+        return self.refresh_token
+    }
+    
+    public func getExpiryTimestamp() -> TimeInterval {
+        return TimeInterval(self.accessTokenExpirationTimestampMs)
     }
 }
 

--- a/spoti-friends/src/common/models/User/User.swift
+++ b/spoti-friends/src/common/models/User/User.swift
@@ -15,10 +15,10 @@ class User: Codable {
     let spotifyId: String
     var spotifyProfile: SpotifyProfile
     var friends: [SpotifyProfile]
-    var authorizationCode: String
-    var spotifyWebAccessToken: SpotifyWebAccessToken
-    var internalAPIAccessToken: InternalAPIAccessToken
-    var authorizationStatus: AuthorizationStatus
+    private var authorizationCode: String
+    private var spotifyWebAccessToken: SpotifyWebAccessToken
+    private var internalAPIAccessToken: InternalAPIAccessToken
+    private var authorizationStatus: AuthorizationStatus
     private var spDcCookie: SpDcCookie
     
     enum CodingKeys: String, CodingKey {
@@ -91,8 +91,20 @@ class User: Codable {
         return self.friends.contains(friend)
     }
     
+    public func getSpotifyWebAccessToken() -> SpotifyWebAccessToken {
+        return self.spotifyWebAccessToken
+    }
+    
+    public func setSpotifyWebAccessToken(_ token: SpotifyWebAccessToken) -> Void {
+        self.spotifyWebAccessToken = token
+    }
+    
     public func getInternalAPIAccessToken() -> InternalAPIAccessToken {
         return self.internalAPIAccessToken
+    }
+    
+    public func getAuthorizationStatus() -> AuthorizationStatus {
+        return self.authorizationStatus
     }
     
     public func getSpDcCookie() -> SpDcCookie {

--- a/spoti-friends/src/common/services/user/UserServiceManager.swift
+++ b/spoti-friends/src/common/services/user/UserServiceManager.swift
@@ -67,6 +67,20 @@ class UserServiceManager {
         }
     }
     
+    func getSpotifyWebAccessToken(forUser user: User) async throws -> SpotifyWebAccessToken {
+        let existingToken = user.getSpotifyWebAccessToken()
+        if (!SpotifyAuth.shared.accessTokenIsExpired(existingToken.getExpiryTimestamp())) {
+            return existingToken
+        }
+        
+        let newToken = try await SpotifyAuth.shared
+            .refreshAccessToken(refreshToken: existingToken.getRefreshToken())
+        user.setSpotifyWebAccessToken(newToken)
+        try await userService.updateUserInDB(user)
+        
+        return newToken
+    }
+    
     /// Retrieves the Spotify internal API access token for the given user.
     ///
     /// If the user already has an existing internal API access token, it will be reused if still valid.

--- a/spoti-friends/src/common/services/user/UserServiceManager.swift
+++ b/spoti-friends/src/common/services/user/UserServiceManager.swift
@@ -67,6 +67,14 @@ class UserServiceManager {
         }
     }
     
+    /// Retrieves the Spotify Web Access Token for the given user.
+    ///
+    /// If the user already has an existing access token, it will be reused if still valid.
+    /// Otherwise, a new token is fetched using the `SpotifyAuth` service.
+    ///
+    /// - Parameter user: The `User` to fetch the token for.
+    /// - Returns: An `SpotifyWebAccessToken` for making authenticated requests to Spotify's Web API.
+    /// - Throws: An error if token retrieval fails.
     func getSpotifyWebAccessToken(forUser user: User) async throws -> SpotifyWebAccessToken {
         let existingToken = user.getSpotifyWebAccessToken()
         if (!SpotifyAuth.shared.accessTokenIsExpired(existingToken.getExpiryTimestamp())) {

--- a/spoti-friends/src/common/views/AuthenticatedView.swift
+++ b/spoti-friends/src/common/views/AuthenticatedView.swift
@@ -6,7 +6,9 @@ struct AuthenticatedView: View {
     @EnvironmentObject var authorizationViewModel: AuthorizationViewModel
     
     init() {
-        _friendActivityViewModel = StateObject(wrappedValue: FriendActivityViewModel(user: AuthorizationViewModel().user, friendActivites: []))
+        _friendActivityViewModel = StateObject(
+            wrappedValue: FriendActivityViewModel(user: nil, friendActivites: [])
+        )
         
         let standardAppearance = UITabBarAppearance()
         standardAppearance.backgroundColor = UIColor(Color.PresetColour.darkgrey)
@@ -23,15 +25,19 @@ struct AuthenticatedView: View {
                 Label("Friend Activity", systemImage: "figure.socialdance")
             }
             .environmentObject(friendActivityViewModel)
-//            ProfileView(profile: friendActivityViewModel.user.spotifyProfile ?? SpotifyProfile()).tabItem {
-//                Label("My Profile", systemImage: "person")
-//            }
-//            .environmentObject(authorizationViewModel)
-//            .environmentObject(friendActivityViewModel)
+            ProfileView(profile: friendActivityViewModel.user?.spotifyProfile ?? SpotifyProfileMock.jimHalpert).tabItem {
+                Label("My Profile", systemImage: "person")
+            }
+            .environmentObject(authorizationViewModel)
+            .environmentObject(friendActivityViewModel)
         }
         .tint(Color.PresetColour.spotifyGreen)
         .onAppear {
-            friendActivityViewModel.user = authorizationViewModel.user
+            guard let signedInUser = authorizationViewModel.user else {
+                printError("Expected user but found none (AuthenticatedView)")
+                return
+            }
+            friendActivityViewModel.user = signedInUser
         }
     }
 }

--- a/spoti-friends/src/friendActivity/views/ListeningActivityDetails.swift
+++ b/spoti-friends/src/friendActivity/views/ListeningActivityDetails.swift
@@ -15,19 +15,19 @@ struct ListeningActivityDetails: View {
     let currentTrack: CurrentOrMostRecentTrack
     let trackDetails: Track
     let artists: [Artist]
-    let context: TrackContext
+    let context: TrackContext?
     @State var contextIcon: Image
     
     init(profile: SpotifyProfile, currentTrack: CurrentOrMostRecentTrack) {
         self.profile = profile
         self.currentTrack = currentTrack
         self.trackDetails = currentTrack.track
-        self.artists = (currentTrack.track.artists)
-        self.context = (currentTrack.track.context)
+        self.artists = currentTrack.track.artists
+        self.context = currentTrack.track.context
         self.contextIcon = getImageForContextType()
         
         func getImageForContextType() -> Image {
-            let contextType = currentTrack.track.context.type
+            let contextType = currentTrack.track.context?.type
             
             switch contextType {
             case .album: return Image(systemName: "smallcircle.circle")
@@ -52,7 +52,7 @@ struct ListeningActivityDetails: View {
             }
             
             // Song details row
-            HStack {
+            HStack(spacing: 4) {
                 Link(destination: URL(string: trackDetails.spotifyUri)!) {
                     Text(trackDetails.name)
                         .lineLimit(1)
@@ -74,12 +74,14 @@ struct ListeningActivityDetails: View {
             }
             
             // Context details row
-            Link(destination: URL(string: context.spotifyUri)!) {
-                HStack {
-                    contextIcon
-                        .padding(.trailing, -6)
-                    Text(trackDetails.context.name)
-                        .lineLimit(1)
+            if let context = context {
+                Link(destination: URL(string: context.spotifyUri)!) {
+                    HStack {
+                        contextIcon
+                            .padding(.trailing, -6)
+                        Text(trackDetails.context?.name ?? "")
+                            .lineLimit(1)
+                    }
                 }
             }
         }

--- a/spoti-friends/src/friendActivity/views/TrackTimestampView.swift
+++ b/spoti-friends/src/friendActivity/views/TrackTimestampView.swift
@@ -13,10 +13,6 @@ struct TrackTimestampView: View {
     
     var body: some View {
         if nowPlaying {
-            //            Image(.nowPlaying)
-            //                .resizable()
-            //                .aspectRatio(contentMode: .fit)
-            //                .frame(width: 16, height: 16)
             AnimatedSoundbarsView()
                 .frame(width: 16, height: 16)
         } else {

--- a/spoti-friends/src/profile/viewModels/ProfileViewModel.swift
+++ b/spoti-friends/src/profile/viewModels/ProfileViewModel.swift
@@ -15,7 +15,7 @@ import Foundation
 ///   - cacheClearTimer: A timer used to automatically clear the cache every 12 hours.
 ///
 class ProfileViewModel: ObservableObject {
-    @Published var user: User
+    @Published var user: User?
     @Published private var topTracksCache: [TimeRange: [Track]] = [:]
     @Published private var topArtistsCache: [TimeRange: [Artist]] = [:]
     private var cacheClearTimer: Timer?
@@ -23,7 +23,7 @@ class ProfileViewModel: ObservableObject {
     /// Initializes the `ProfileViewModel` with the specified `User` and starts the cache timer.
     ///
     /// - Parameter user: The currently logged-in `User` object.
-    init(user: User){
+    init(user: User?){
         self.user = user
         startCacheTimer()
     }
@@ -51,206 +51,221 @@ class ProfileViewModel: ObservableObject {
     /// Fetches the current user's follower count from Spotify.
     ///
     /// - Returns: The number of followers the current user has, or `-1` if the fetch fails.
-//    @MainActor func getCurrentUsersFollowerCount() async -> Int {
-//        do {
-//            let accessToken = try await self.user.getSpotifyWebAccessToken().access_token
-//            let response = try await SpotifyAPI.shared.fetch(method: .GET,
-//                                                             endpoint: .getCurrentUsersProfile,
-//                                                             responseType: GetCurrentUserProfileResponse.self,
-//                                                             accessToken: accessToken)
-//            return response.followers.total
-//        } catch {
-//            printError("\(error)")
-//        }
-//        return -1
-//    }
-//    
-//    /// Fetches the current user's public playlist count from Spotify.
-//    ///
-//    /// This count only includes public playlists.
-//    ///
-//    /// - Returns: The number of public playlists, or `-1` if the fetch fails.
-//    @MainActor func getCurrentUsersPlaylistCount() async -> Int {
-//        do {
-//            let accessToken = try await self.user.getSpotifyWebAccessToken().access_token
-//            let response = try await SpotifyAPI.shared.fetch(method: .GET,
-//                                                             endpoint: .getCurrentUsersPlaylists,
-//                                                             responseType: GetCurrentUserPlayistsResponse.self,
-//                                                             accessToken: accessToken)
-//            return response.total
-//        } catch {
-//            printError("\(error)")
-//        }
-//        return -1
-//    }
-//    
-//    enum ProfileItems {
-//        case recentTracks
-//        case topTracks
-//        case topArtists
-//    }
-//    
-//    /// Fetches the specified profile item (recent tracks, top tracks, or top artists) based on the time range.
-//    ///
-//    /// - Parameters:
-//    ///   - forItem: The profile item to fetch (recent tracks, top tracks, or top artists).
-//    ///   - timeRange: The time range over which to calculate the data. Default is `.oneMonth`.
-//    /// - Returns: A `ProfileItemsResponse?` that contains either tracks or artists.
-//    @MainActor func viewMoreForCurrentUser(forItem: ProfileItems, timeRange: TimeRange = .oneMonth) async -> ProfileItemsResponse? {
-//        let limit = 20
-//        
-//        switch forItem {
-//        case .recentTracks:
-//            let tracks = await getCurrentUsersRecentTracks(limit: limit)
-//            return .tracks(tracks)
-//        case .topTracks:
-//            let tracks = await getCurrentUsersTopTracks(timeRange: timeRange, limit: limit)
-//            return .tracks(tracks)
-//        case .topArtists:
-//            let artists = await getCurrentUsersTopArtists(timeRange: timeRange, limit: limit)
-//            return .artists(artists)
-//        }
-//    }
-//    
-//    /// Fetches the current user's recent tracks.
-//    ///
-//    /// - Parameter limit: The maximum number of items to return. Default: 5. Minimum: 1. Maximum: 50.
-//    /// - Returns: A `TracksWithResponseMetadata?` containing the user's recent tracks.
-//    @MainActor func getCurrentUsersRecentTracks(limit: Int)
-//    async -> TracksWithResponseMetadata? {
-//        do {
-//            let accessToken = try await self.user.getSpotifyWebAccessToken().access_token
-//            let queryParams = [
-//                URLQueryItem(name: "limit", value: String(limit))
-//            ]
-//            let response = try await SpotifyAPI.shared.fetch(method: .GET,
-//                                                             endpoint: .getCurrentUsersRecentTracks,
-//                                                             responseType: GetCurrentUserRecentTracksResponse.self,
-//                                                             accessToken: accessToken,
-//                                                             queryParams: queryParams)
-//            
-//            return TracksWithResponseMetadata(tracks: response.extractTracksFromItems(), isEmpty: response.items.isEmpty)
-//        }
-//        catch {
-//            printError("\(error)")
-//            return nil
-//        }
-//    }
-//    
-//    /// Fetches the current user's top tracks over the specified time range.
-//    ///
-//    /// - Parameters:
-//    ///   - timeRange: The time range over which to calculate the data.
-//    ///   - limit: The maximum number of items to return. Default: 5. Minimum: 1. Maximum: 50.
-//    /// - Returns: A `TracksWithResponseMetadata?` containing the user's top tracks.
-//    @MainActor func getCurrentUsersTopTracks(timeRange: TimeRange, limit: Int)
-//    async -> TracksWithResponseMetadata? {
-//        // The cache should only be used for the "View more" screen – hence the check for limit == 20.
-//        if (limit == 20) {
-//            if let tracks = getTopTracksFromCacheIfExists(timeRange: timeRange) {
-//                printInfo("Found top tracks in cache for time range: \(timeRange)")
-//                return TracksWithResponseMetadata(tracks: tracks, isEmpty: tracks.isEmpty)
-//            }
-//        }
-//        
-//        do {
-//            let accessToken = try await self.user.getSpotifyWebAccessToken().access_token
-//            let queryParams = [
-//                URLQueryItem(name: "time_range", value: timeRange.rawValue),
-//                URLQueryItem(name: "limit", value: String(limit))
-//            ]
-//            let response = try await SpotifyAPI.shared.fetch(method: .GET,
-//                                                             endpoint: .getCurrentUsersTopTracks,
-//                                                             responseType: GetCurrentUserTopTracksResponse.self,
-//                                                             accessToken: accessToken,
-//                                                             queryParams: queryParams)
-//            
-//            // Only cache data when opening in "View more"
-//            if (limit == 20) {
-//                printInfo("Fetched top tracks from Spotify for time range: \(timeRange). Saved to cache.")
-//                cacheThese(topTracks: response.items, forTimeRange: timeRange)
-//            }
-//            return TracksWithResponseMetadata(tracks: response.items, isEmpty: response.items.isEmpty)
-//        }
-//        catch {
-//            printError("\(error)")
-//            return nil
-//        }
-//    }
-//    
-//    /// Retrieves the cached top tracks for the specified time range if they exist.
-//    ///
-//    /// - Parameter timeRange: The time range for the cached data.
-//    /// - Returns: An optional array of `Track` objects if cached data is available.
-//    private func getTopTracksFromCacheIfExists(timeRange: TimeRange) -> [Track]? {
-//        return topTracksCache[timeRange]
-//    }
-//    
-//    /// Caches the specified top tracks for the given time range.
-//    ///
-//    /// - Parameters:
-//    ///   - topTracks: An array of `Track` objects to cache.
-//    ///   - timeRange: The time range for the cached data.
-//    private func cacheThese(topTracks: [Track], forTimeRange timeRange: TimeRange) -> Void {
-//        self.topTracksCache[timeRange] = topTracks
-//    }
-//    
-//    /// Fetches the current user's top artists over the specified time range.
-//    ///
-//    /// - Parameters:
-//    ///   - timeRange: The time range over which to calculate the data.
-//    ///   - limit: The maximum number of items to return. Default: 5. Minimum: 1. Maximum: 50.
-//    /// - Returns: An `ArtistsWithResponseMetadata?` containing the user's top artists.
-//    @MainActor func getCurrentUsersTopArtists(timeRange: TimeRange, limit: Int)
-//    async -> ArtistsWithResponseMetadata? {
-//        // The cache should only be used for the "View more" screen – hence the check for limit == 20.
-//        if (limit == 20) {
-//            if let artists = getTopArtistsFromCacheIfExists(timeRange: timeRange) {
-//                printInfo("Found top artists in cache for time range: \(timeRange)")
-//                return ArtistsWithResponseMetadata(artists: artists, isEmpty: artists.isEmpty)
-//            }
-//        }
-//        
-//        do {
-//            let accessToken = try await self.user.getSpotifyWebAccessToken().access_token
-//            let queryParams = [
-//                URLQueryItem(name: "time_range", value: timeRange.rawValue),
-//                URLQueryItem(name: "limit", value: String(limit))
-//            ]
-//            let response = try await SpotifyAPI.shared.fetch(method: .GET,
-//                                                             endpoint: .getCurrentUsersTopArtists,
-//                                                             responseType: GetCurrentUserTopArtistsResponse.self,
-//                                                             accessToken: accessToken,
-//                                                             queryParams: queryParams)
-//            
-//            // Only cache data when opening in "View more"
-//            if (limit == 20) {
-//                printInfo("Fetched top artists from Spotify for time range: \(timeRange). Saved to cache.")
-//                cacheThese(topArtists: response.items, forTimeRange: timeRange)
-//            }
-//            return ArtistsWithResponseMetadata(artists: response.items, isEmpty: response.items.isEmpty)
-//        }
-//        catch {
-//            printError("\(error)")
-//            return nil
-//        }
-//    }
-//    
-//    /// Retrieves the cached top artists for the specified time range if they exist.
-//    ///
-//    /// - Parameter timeRange: The time range for the cached data.
-//    /// - Returns: An optional array of `Artist` objects if cached data is available.
-//    private func getTopArtistsFromCacheIfExists(timeRange: TimeRange) -> [Artist]? {
-//        return topArtistsCache[timeRange]
-//    }
-//    
-//    /// Caches the specified top artists for the given time range.
-//    ///
-//    /// - Parameters:
-//    ///   - topArtists: An array of `Artist` objects to cache.
-//    ///   - timeRange: The time range for the cached data.
-//    private func cacheThese(topArtists: [Artist], forTimeRange timeRange: TimeRange) -> Void {
-//        self.topArtistsCache[timeRange] = topArtists
-//    }
+    @MainActor func getCurrentUsersFollowerCount() async -> Int {
+        do {
+            guard let signedInUser = user else { throw AuthorizationError.missingUser }
+            let accessToken = try await UserServiceManager.shared
+                .getSpotifyWebAccessToken(forUser: signedInUser)
+                .getAccessToken()
+            let response = try await SpotifyAPI.shared.fetch(method: .GET,
+                                                             endpoint: .getCurrentUsersProfile,
+                                                             responseType: GetCurrentUserProfileResponse.self,
+                                                             accessToken: accessToken)
+            return response.followers.total
+        } catch {
+            printError("When getting the current user's follower count: \(error)")
+            return -1
+        }
+    }
+    
+    /// Fetches the current user's public playlist count from Spotify.
+    ///
+    /// This count only includes public playlists.
+    ///
+    /// - Returns: The number of public playlists, or `-1` if the fetch fails.
+    @MainActor func getCurrentUsersPlaylistCount() async -> Int {
+        do {
+            guard let signedInUser = user else { throw AuthorizationError.missingUser }
+            let accessToken = try await UserServiceManager.shared
+                .getSpotifyWebAccessToken(forUser: signedInUser)
+                .getAccessToken()
+            let response = try await SpotifyAPI.shared.fetch(method: .GET,
+                                                             endpoint: .getCurrentUsersPlaylists,
+                                                             responseType: GetCurrentUserPlayistsResponse.self,
+                                                             accessToken: accessToken)
+            return response.total
+        } catch {
+            printError("When getting the current user's playlist count: \(error)")
+            return -1
+        }
+    }
+    
+    enum ProfileItems {
+        case recentTracks
+        case topTracks
+        case topArtists
+    }
+    
+    /// Fetches the specified profile item (recent tracks, top tracks, or top artists) based on the time range.
+    ///
+    /// - Parameters:
+    ///   - forItem: The profile item to fetch (recent tracks, top tracks, or top artists).
+    ///   - timeRange: The time range over which to calculate the data. Default is `.oneMonth`.
+    /// - Returns: A `ProfileItemsResponse?` that contains either tracks or artists.
+    @MainActor func viewMoreForCurrentUser(forItem: ProfileItems, timeRange: TimeRange = .oneMonth) async -> ProfileItemsResponse? {
+        let limit = 20
+        
+        switch forItem {
+        case .recentTracks:
+            let tracks = await getCurrentUsersRecentTracks(limit: limit)
+            return .tracks(tracks)
+        case .topTracks:
+            let tracks = await getCurrentUsersTopTracks(timeRange: timeRange, limit: limit)
+            return .tracks(tracks)
+        case .topArtists:
+            let artists = await getCurrentUsersTopArtists(timeRange: timeRange, limit: limit)
+            return .artists(artists)
+        }
+    }
+    
+    /// Fetches the current user's recent tracks.
+    ///
+    /// - Parameter limit: The maximum number of items to return. Default: 5. Minimum: 1. Maximum: 50.
+    /// - Returns: A `TracksWithResponseMetadata?` containing the user's recent tracks.
+    @MainActor func getCurrentUsersRecentTracks(limit: Int)
+    async -> TracksWithResponseMetadata? {
+        do {
+            guard let signedInUser = user else { throw AuthorizationError.missingUser }
+            let accessToken = try await UserServiceManager.shared
+                .getSpotifyWebAccessToken(forUser: signedInUser)
+                .getAccessToken()
+            let queryParams = [
+                URLQueryItem(name: "limit", value: String(limit))
+            ]
+            let response = try await SpotifyAPI.shared.fetch(method: .GET,
+                                                             endpoint: .getCurrentUsersRecentTracks,
+                                                             responseType: GetCurrentUserRecentTracksResponse.self,
+                                                             accessToken: accessToken,
+                                                             queryParams: queryParams)
+            
+            return TracksWithResponseMetadata(tracks: response.extractTracksFromItems(), isEmpty: response.items.isEmpty)
+        }
+        catch {
+            printError("When getting the current user's recent tracks: \(error)")
+            return nil
+        }
+    }
+    
+    /// Fetches the current user's top tracks over the specified time range.
+    ///
+    /// - Parameters:
+    ///   - timeRange: The time range over which to calculate the data.
+    ///   - limit: The maximum number of items to return. Default: 5. Minimum: 1. Maximum: 50.
+    /// - Returns: A `TracksWithResponseMetadata?` containing the user's top tracks.
+    @MainActor func getCurrentUsersTopTracks(timeRange: TimeRange, limit: Int)
+    async -> TracksWithResponseMetadata? {
+        // The cache should only be used for the "View more" screen – hence the check for limit == 20.
+        if (limit == 20) {
+            if let tracks = getTopTracksFromCacheIfExists(timeRange: timeRange) {
+                printInfo("Found top tracks in cache for time range: \(timeRange)")
+                return TracksWithResponseMetadata(tracks: tracks, isEmpty: tracks.isEmpty)
+            }
+        }
+        
+        do {
+            guard let signedInUser = user else { throw AuthorizationError.missingUser }
+            let accessToken = try await UserServiceManager.shared
+                .getSpotifyWebAccessToken(forUser: signedInUser)
+                .getAccessToken()
+            let queryParams = [
+                URLQueryItem(name: "time_range", value: timeRange.rawValue),
+                URLQueryItem(name: "limit", value: String(limit))
+            ]
+            let response = try await SpotifyAPI.shared.fetch(method: .GET,
+                                                             endpoint: .getCurrentUsersTopTracks,
+                                                             responseType: GetCurrentUserTopTracksResponse.self,
+                                                             accessToken: accessToken,
+                                                             queryParams: queryParams)
+            
+            // Only cache data when opening in "View more"
+            if (limit == 20) {
+                printInfo("Fetched top tracks from Spotify for time range: \(timeRange). Saved to cache.")
+                cacheThese(topTracks: response.items, forTimeRange: timeRange)
+            }
+            return TracksWithResponseMetadata(tracks: response.items, isEmpty: response.items.isEmpty)
+        }
+        catch {
+            printError("When getting the current user's top tracks: \(error)")
+            return nil
+        }
+    }
+    
+    /// Retrieves the cached top tracks for the specified time range if they exist.
+    ///
+    /// - Parameter timeRange: The time range for the cached data.
+    /// - Returns: An optional array of `Track` objects if cached data is available.
+    private func getTopTracksFromCacheIfExists(timeRange: TimeRange) -> [Track]? {
+        return topTracksCache[timeRange]
+    }
+    
+    /// Caches the specified top tracks for the given time range.
+    ///
+    /// - Parameters:
+    ///   - topTracks: An array of `Track` objects to cache.
+    ///   - timeRange: The time range for the cached data.
+    private func cacheThese(topTracks: [Track], forTimeRange timeRange: TimeRange) -> Void {
+        self.topTracksCache[timeRange] = topTracks
+    }
+    
+    /// Fetches the current user's top artists over the specified time range.
+    ///
+    /// - Parameters:
+    ///   - timeRange: The time range over which to calculate the data.
+    ///   - limit: The maximum number of items to return. Default: 5. Minimum: 1. Maximum: 50.
+    /// - Returns: An `ArtistsWithResponseMetadata?` containing the user's top artists.
+    @MainActor func getCurrentUsersTopArtists(timeRange: TimeRange, limit: Int)
+    async -> ArtistsWithResponseMetadata? {
+        // The cache should only be used for the "View more" screen – hence the check for limit == 20.
+        if (limit == 20) {
+            if let artists = getTopArtistsFromCacheIfExists(timeRange: timeRange) {
+                printInfo("Found top artists in cache for time range: \(timeRange)")
+                return ArtistsWithResponseMetadata(artists: artists, isEmpty: artists.isEmpty)
+            }
+        }
+        
+        do {
+            guard let signedInUser = user else { throw AuthorizationError.missingUser }
+            let accessToken = try await UserServiceManager.shared
+                .getSpotifyWebAccessToken(forUser: signedInUser)
+                .getAccessToken()
+            let queryParams = [
+                URLQueryItem(name: "time_range", value: timeRange.rawValue),
+                URLQueryItem(name: "limit", value: String(limit))
+            ]
+            let response = try await SpotifyAPI.shared.fetch(method: .GET,
+                                                             endpoint: .getCurrentUsersTopArtists,
+                                                             responseType: GetCurrentUserTopArtistsResponse.self,
+                                                             accessToken: accessToken,
+                                                             queryParams: queryParams)
+            
+            // Only cache data when opening in "View more"
+            if (limit == 20) {
+                printInfo("Fetched top artists from Spotify for time range: \(timeRange). Saved to cache.")
+                cacheThese(topArtists: response.items, forTimeRange: timeRange)
+            }
+            return ArtistsWithResponseMetadata(artists: response.items, isEmpty: response.items.isEmpty)
+        }
+        catch {
+            printError("When getting the current user's top artists: \(error)")
+            return nil
+        }
+    }
+    
+    /// Retrieves the cached top artists for the specified time range if they exist.
+    ///
+    /// - Parameter timeRange: The time range for the cached data.
+    /// - Returns: An optional array of `Artist` objects if cached data is available.
+    private func getTopArtistsFromCacheIfExists(timeRange: TimeRange) -> [Artist]? {
+        return topArtistsCache[timeRange]
+    }
+    
+    /// Caches the specified top artists for the given time range.
+    ///
+    /// - Parameters:
+    ///   - topArtists: An array of `Artist` objects to cache.
+    ///   - timeRange: The time range for the cached data.
+    private func cacheThese(topArtists: [Artist], forTimeRange timeRange: TimeRange) -> Void {
+        self.topArtistsCache[timeRange] = topArtists
+    }
     
 }

--- a/spoti-friends/src/profile/views/ProfileDetails.swift
+++ b/spoti-friends/src/profile/views/ProfileDetails.swift
@@ -1,85 +1,85 @@
-//import SwiftUI
-//
-//
-///// Renders the View for a user's Spotify Profile details.
-///// In other words: their profile image, display name, follower count, and playlist count.
-/////
-///// - Parameters:
-/////   - profile: The `SpotifyProfile` to display the details for.
-//struct ProfileDetails: View {
-//    let profile: SpotifyProfile
-//    @State private var followerCount: Int?
-//    @State private var playlistCount: Int?
-//    @State private var fetchedDetails: Bool = true
-//    @EnvironmentObject var profileViewModel: ProfileViewModel
-//    @EnvironmentObject var friendActivityViewModel: FriendActivityViewModel
-//    
-//    init(profile: SpotifyProfile) {
-//        self.profile = profile
-//    }
-//    
-//    var body: some View {
-//        HStack(spacing: 12) {
-//            ProfileImage(imageName: profile.spotifyId, width: 80, height: 80)
-//                .environmentObject(friendActivityViewModel)
-//            
-//            VStack(alignment: .leading) {
-//                // Display name
-//                Text(profile.displayName)
-//                    .foregroundStyle(Color.PresetColour.whitePrimary)
-//                
-//                Spacer().frame(height: 4)
-//                
-//                // Follower and playlist counts
-//                HStack {
-//                    if (followerCount == nil || playlistCount == nil) {
-//                        // Show placeholder while fetching data
-//                        Group {
-//                            Text("\(String(describing: followerCount)) followers")
-//                                .redacted(reason: .placeholder)
-//                            Text("\(String(describing: playlistCount)) playlists")
-//                                .redacted(reason: .placeholder)
-//                        }
-//                        .lineLimit(1)
-//                        .opacity(fetchedDetails ? 0.6 : 1.0)
-//                        .animation(
-//                            .easeInOut(duration: 0.8)
-//                            .repeatForever(autoreverses: true),
-//                            value: fetchedDetails
-//                        )
-//                    } else {
-//                        // Show data once it is fetched
-//                        Text("\(followerCount!) followers")
-//                        Text("•")
-//                        Text("\(playlistCount!) playlists")
-//                    }
-//                }
-//                .foregroundStyle(Color.PresetColour.whiteSecondary)
-//                .onAppear {
-//                    fetchedDetails = false
-//                    Task {
-//                        // NOTE: Comment out these two lines to fix SwiftUI Previews
-//                        followerCount = await profileViewModel.getCurrentUsersFollowerCount()
-//                        playlistCount = await profileViewModel.getCurrentUsersPlaylistCount()
-//                        fetchedDetails = true
-//                    }
-//                }
-//                
-//                Spacer().frame(height: 8)
-//                
-//                // Open in Spotify button
-//                OpenInSpotifyButton(redirectLink: profile.spotifyUri)
-//            }
-//            Spacer()
-//        }
-//    }
-//}
-//
-//#Preview {
-//    ZStack {
-//        let user = UserMock.userJimHalpert
-//        ProfileDetails(profile: user.spotifyProfile)
-//            .environmentObject(ProfileViewModel(user: user))
-//            .environmentObject(FriendActivityViewModel(user: user, friendActivites: []))
-//    }
-//}
+import SwiftUI
+
+
+/// Renders the View for a user's Spotify Profile details.
+/// In other words: their profile image, display name, follower count, and playlist count.
+///
+/// - Parameters:
+///   - profile: The `SpotifyProfile` to display the details for.
+struct ProfileDetails: View {
+    let profile: SpotifyProfile
+    @State private var followerCount: Int?
+    @State private var playlistCount: Int?
+    @State private var fetchedDetails: Bool = true
+    @EnvironmentObject var profileViewModel: ProfileViewModel
+    @EnvironmentObject var friendActivityViewModel: FriendActivityViewModel
+    
+    init(profile: SpotifyProfile) {
+        self.profile = profile
+    }
+    
+    var body: some View {
+        HStack(spacing: 12) {
+            ProfileImage(imageName: profile.spotifyId, width: 80, height: 80)
+                .environmentObject(friendActivityViewModel)
+            
+            VStack(alignment: .leading) {
+                // Display name
+                Text(profile.displayName)
+                    .foregroundStyle(Color.PresetColour.whitePrimary)
+                
+                Spacer().frame(height: 4)
+                
+                // Follower and playlist counts
+                HStack {
+                    if (followerCount == nil || playlistCount == nil) {
+                        // Show placeholder while fetching data
+                        Group {
+                            Text("\(String(describing: followerCount)) followers")
+                                .redacted(reason: .placeholder)
+                            Text("\(String(describing: playlistCount)) playlists")
+                                .redacted(reason: .placeholder)
+                        }
+                        .lineLimit(1)
+                        .opacity(fetchedDetails ? 0.6 : 1.0)
+                        .animation(
+                            .easeInOut(duration: 0.8)
+                            .repeatForever(autoreverses: true),
+                            value: fetchedDetails
+                        )
+                    } else {
+                        // Show data once it is fetched
+                        Text("\(followerCount!) followers")
+                        Text("•")
+                        Text("\(playlistCount!) playlists")
+                    }
+                }
+                .foregroundStyle(Color.PresetColour.whiteSecondary)
+                .onAppear {
+                    fetchedDetails = false
+                    Task {
+                        // NOTE: Comment out these two lines to fix SwiftUI Previews
+                        followerCount = await profileViewModel.getCurrentUsersFollowerCount()
+                        playlistCount = await profileViewModel.getCurrentUsersPlaylistCount()
+                        fetchedDetails = true
+                    }
+                }
+                
+                Spacer().frame(height: 8)
+                
+                // Open in Spotify button
+                OpenInSpotifyButton(redirectLink: profile.spotifyUri)
+            }
+            Spacer()
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        let user = UserMock.userJimHalpert
+        ProfileDetails(profile: user.spotifyProfile)
+            .environmentObject(ProfileViewModel(user: user))
+            .environmentObject(FriendActivityViewModel(user: user, friendActivites: []))
+    }
+}

--- a/spoti-friends/src/profile/views/ProfileView.swift
+++ b/spoti-friends/src/profile/views/ProfileView.swift
@@ -1,159 +1,159 @@
-//import SwiftUI
-//
-///// Renders the View for a user's profile, such as their details and top songs.
-/////
-///// - Parameters:
-/////   - profile: The Spotify profile to display.
-/////   - recentTracks: A list of the profile's recently played tracks.
-/////   - topTracks: A list of the profile's top tracks over the last month.
-/////   - topArtists: A list of the profile's top artists over the last month.
-/////
-///// - Returns: A view for the user's Spotify Profile.
-//struct ProfileView: View {
-//    let profile: SpotifyProfile
-//    @State private var recentTracks: ProfileViewModel.TracksWithResponseMetadata
-//    @State private var topTracks: ProfileViewModel.TracksWithResponseMetadata
-//    @State private var topArtists: ProfileViewModel.ArtistsWithResponseMetadata
-//    @StateObject private var profileViewModel: ProfileViewModel
-//    @EnvironmentObject var authorizationViewModel: AuthorizationViewModel
-//    @EnvironmentObject var friendActivityViewModel: FriendActivityViewModel
-//    
-//    /// NOTE: `topTracks` and `topArtists` default to `[]` so that we don't need to pass them in from `AuthenticatedView`.
-//    /// However, we do want to pass in mock data for previews, so that's why we want them as optional parameters.
-//    init(profile: SpotifyProfile, recentTracks: [Track] = [], topTracks: [Track] = [], topArtists: [Artist] = []) {
-//        self.profile = profile
-//        _profileViewModel = StateObject(wrappedValue: ProfileViewModel(user: AuthorizationViewModel().user))
-//        self.recentTracks = ProfileViewModel.TracksWithResponseMetadata(tracks: recentTracks)
-//        self.topTracks = ProfileViewModel.TracksWithResponseMetadata(tracks: topTracks)
-//        self.topArtists = ProfileViewModel.ArtistsWithResponseMetadata(artists: topArtists)
-//    }
-//    
-//    var body: some View {
-//        NavigationStack {
-//            GeometryReader { reader in
-//                ScrollView {
-//                    VStack (alignment: .leading, spacing: 34) {
-//                        // Profile Details
-//                        ProfileDetails(profile: profile)
-//                            .environmentObject(profileViewModel)
-//                            .environmentObject(friendActivityViewModel)
-//                        
-//                        // Recent Tracks
-//                        VStack (alignment: .leading) {
-//                            Text("Recent Songs")
-//                                .font(.body)
-//                                .foregroundStyle(Color.PresetColour.whitePrimary)
-//                            
-//                            if recentTracks.isEmpty {
-//                                Text("It's oddly quiet here...")
-//                                    .font(.callout)
-//                                    .foregroundStyle(Color.PresetColour.whiteSecondary)
-//                                    .padding(.vertical, 4)
-//                            } else {
-//                                TrackList(tracks: recentTracks.tracks)
-//                                ViewMoreButton(destination: ViewMoreRecentTracks(profile: profile)
-//                                    .environmentObject(profileViewModel))
-//                                .padding(.top, 4)
-//                            }
-//                        }
-//                        
-//                        // Top Tracks
-//                        VStack (alignment: .leading) {
-//                            Text("Top Songs")
-//                                .font(.body)
-//                                .foregroundStyle(Color.PresetColour.whitePrimary)
-//                            Text("From this month")
-//                                .font(.footnote)
-//                                .foregroundStyle(Color.PresetColour.whiteSecondary)
-//                            
-//                            if topTracks.isEmpty {
-//                                Text("Not enough listening data this month.")
-//                                    .font(.callout)
-//                                    .foregroundStyle(Color.PresetColour.whiteSecondary)
-//                                    .padding(.vertical, 4)
-//                            } else {
-//                                TrackList(tracks: topTracks.tracks)
-//                                ViewMoreButton(destination: ViewMoreTopSongs(profile: profile)
-//                                    .environmentObject(profileViewModel))
-//                                .padding(.top, 4)
-//                            }
-//                        }
-//                        
-//                        // Top Artists
-//                        VStack (alignment: .leading) {
-//                            Text("Top Artists")
-//                                .font(.body)
-//                                .foregroundStyle(Color.PresetColour.whitePrimary)
-//                            Text("From this month")
-//                                .font(.footnote)
-//                                .foregroundStyle(Color.PresetColour.whiteSecondary)
-//                            
-//                            if topArtists.isEmpty {
-//                                Text("Not enough listening data this month.")
-//                                    .font(.callout)
-//                                    .foregroundStyle(Color.PresetColour.whiteSecondary)
-//                                    .padding(.vertical, 4)
-//                            } else {
-//                                ArtistList(artists: topArtists.artists)
-//                                ViewMoreButton(destination: ViewMoreTopArtists(profile: profile)
-//                                    .environmentObject(profileViewModel))
-//                                .padding(.top, 4)
-//                            }
-//                        }
-//                        Spacer()
-//                    }
-//                    .frame(minHeight: reader.size.height)
-//                    .padding(.horizontal, 20)
-//                    
-//                    // Logout Button
-//                    LogoutButton()
-//                        .padding(.bottom, 10)
-//                }
-//                .padding(.top)
-//                .background(Color.PresetGradient.profileViewGradient(profile: profile))
-//                .onAppear {
-//                    profileViewModel.user = authorizationViewModel.user
-//                    
-//                    Task {
-//                        // Comment out these lines for SwiftUI Previews
-//                        recentTracks = await profileViewModel.getCurrentUsersRecentTracks(limit: 5) ?? ProfileViewModel.TracksWithResponseMetadata(tracks: [])
-//                        topTracks = await profileViewModel.getCurrentUsersTopTracks(timeRange: .oneMonth, limit: 5) ?? ProfileViewModel.TracksWithResponseMetadata(tracks: [])
-//                        topArtists = await profileViewModel.getCurrentUsersTopArtists(timeRange: .oneMonth, limit: 5) ?? ProfileViewModel.ArtistsWithResponseMetadata(artists: [])
-//                    }
-//                }
-//            }
-//        }
-//    }
-//    
-//    // Logout button
-//    struct LogoutButton: View {
-//        @EnvironmentObject private var authorizationViewModel: AuthorizationViewModel
-//        
-//        var body: some View {
-//            let buttonLabel = "Log out"
-//            Button(action: {
-//                authorizationViewModel.signOutUser()
-//            }) {
-//                Text(buttonLabel)
-//                    .frame(width: 320, height: 50)
-//                    .background(Color.PresetColour.transparentMaroon)
-//                    .foregroundColor(Color.PresetColour.red)
-//                    .fontWeight(.semibold)
-//                    .cornerRadius(12)
-//            }
-//        }
-//    }
-//}
-//
-//#Preview {
-//    ZStack {
-//        let user = UserMock.userJimHalpert
-//        let recentTracks = [TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor]
-//        let topTracks = [TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor]
-//        let topArtists = [ArtistMock.zachBryan, ArtistMock.jonBellion, ArtistMock.oliviaRodrigo, ArtistMock.kaceyMusgraves]
-//        
-//        ProfileView(profile: user.spotifyProfile!, recentTracks: recentTracks, topTracks: topTracks, topArtists: topArtists)
-//            .environmentObject(AuthorizationViewModel())
-//            .environmentObject(FriendActivityViewModel(user: user, friendActivites: []))
-//    }
-//}
+import SwiftUI
+
+/// Renders the View for a user's profile, such as their details and top songs.
+///
+/// - Parameters:
+///   - profile: The Spotify profile to display.
+///   - recentTracks: A list of the profile's recently played tracks.
+///   - topTracks: A list of the profile's top tracks over the last month.
+///   - topArtists: A list of the profile's top artists over the last month.
+///
+/// - Returns: A view for the user's Spotify Profile.
+struct ProfileView: View {
+    let profile: SpotifyProfile
+    @State private var recentTracks: ProfileViewModel.TracksWithResponseMetadata
+    @State private var topTracks: ProfileViewModel.TracksWithResponseMetadata
+    @State private var topArtists: ProfileViewModel.ArtistsWithResponseMetadata
+    @StateObject private var profileViewModel: ProfileViewModel
+    @EnvironmentObject var authorizationViewModel: AuthorizationViewModel
+    @EnvironmentObject var friendActivityViewModel: FriendActivityViewModel
+    
+    /// NOTE: `topTracks` and `topArtists` default to `[]` so that we don't need to pass them in from `AuthenticatedView`.
+    /// However, we do want to pass in mock data for previews, so that's why we want them as optional parameters.
+    init(profile: SpotifyProfile, recentTracks: [Track] = [], topTracks: [Track] = [], topArtists: [Artist] = []) {
+        _profileViewModel = StateObject(wrappedValue: ProfileViewModel(user: AuthorizationViewModel().user))
+        self.profile = profile
+        self.recentTracks = ProfileViewModel.TracksWithResponseMetadata(tracks: recentTracks)
+        self.topTracks = ProfileViewModel.TracksWithResponseMetadata(tracks: topTracks)
+        self.topArtists = ProfileViewModel.ArtistsWithResponseMetadata(artists: topArtists)
+    }
+    
+    var body: some View {
+        NavigationStack {
+            GeometryReader { reader in
+                ScrollView {
+                    VStack (alignment: .leading, spacing: 34) {
+                        // Profile Details
+                        ProfileDetails(profile: profile)
+                            .environmentObject(profileViewModel)
+                            .environmentObject(friendActivityViewModel)
+                        
+                        // Recent Tracks
+                        VStack (alignment: .leading) {
+                            Text("Recent Songs")
+                                .font(.body)
+                                .foregroundStyle(Color.PresetColour.whitePrimary)
+                            
+                            if recentTracks.isEmpty {
+                                Text("It's oddly quiet here...")
+                                    .font(.callout)
+                                    .foregroundStyle(Color.PresetColour.whiteSecondary)
+                                    .padding(.vertical, 4)
+                            } else {
+                                TrackList(tracks: recentTracks.tracks)
+                                ViewMoreButton(destination: ViewMoreRecentTracks(profile: profile)
+                                    .environmentObject(profileViewModel))
+                                .padding(.top, 4)
+                            }
+                        }
+                        
+                        // Top Tracks
+                        VStack (alignment: .leading) {
+                            Text("Top Songs")
+                                .font(.body)
+                                .foregroundStyle(Color.PresetColour.whitePrimary)
+                            Text("From this month")
+                                .font(.footnote)
+                                .foregroundStyle(Color.PresetColour.whiteSecondary)
+                            
+                            if topTracks.isEmpty {
+                                Text("Not enough listening data this month.")
+                                    .font(.callout)
+                                    .foregroundStyle(Color.PresetColour.whiteSecondary)
+                                    .padding(.vertical, 4)
+                            } else {
+                                TrackList(tracks: topTracks.tracks)
+                                ViewMoreButton(destination: ViewMoreTopSongs(profile: profile)
+                                    .environmentObject(profileViewModel))
+                                .padding(.top, 4)
+                            }
+                        }
+                        
+                        // Top Artists
+                        VStack (alignment: .leading) {
+                            Text("Top Artists")
+                                .font(.body)
+                                .foregroundStyle(Color.PresetColour.whitePrimary)
+                            Text("From this month")
+                                .font(.footnote)
+                                .foregroundStyle(Color.PresetColour.whiteSecondary)
+                            
+                            if topArtists.isEmpty {
+                                Text("Not enough listening data this month.")
+                                    .font(.callout)
+                                    .foregroundStyle(Color.PresetColour.whiteSecondary)
+                                    .padding(.vertical, 4)
+                            } else {
+                                ArtistList(artists: topArtists.artists)
+                                ViewMoreButton(destination: ViewMoreTopArtists(profile: profile)
+                                    .environmentObject(profileViewModel))
+                                .padding(.top, 4)
+                            }
+                        }
+                        Spacer()
+                    }
+                    .frame(minHeight: reader.size.height)
+                    .padding(.horizontal, 20)
+                    
+                    // Logout Button
+                    LogoutButton()
+                        .padding(.bottom, 10)
+                }
+                .padding(.top)
+                .background(Color.PresetGradient.profileViewGradient(profile: profile))
+                .onAppear {
+                    profileViewModel.user = authorizationViewModel.user
+                    
+                    Task {
+                        // Comment out these lines for SwiftUI Previews
+                        recentTracks = await profileViewModel.getCurrentUsersRecentTracks(limit: 5) ?? ProfileViewModel.TracksWithResponseMetadata(tracks: [])
+                        topTracks = await profileViewModel.getCurrentUsersTopTracks(timeRange: .oneMonth, limit: 5) ?? ProfileViewModel.TracksWithResponseMetadata(tracks: [])
+                        topArtists = await profileViewModel.getCurrentUsersTopArtists(timeRange: .oneMonth, limit: 5) ?? ProfileViewModel.ArtistsWithResponseMetadata(artists: [])
+                    }
+                }
+            }
+        }
+    }
+    
+    // Logout button
+    struct LogoutButton: View {
+        @EnvironmentObject private var authorizationViewModel: AuthorizationViewModel
+        
+        var body: some View {
+            let buttonLabel = "Log out"
+            Button(action: {
+                authorizationViewModel.signOutUser()
+            }) {
+                Text(buttonLabel)
+                    .frame(width: 320, height: 50)
+                    .background(Color.PresetColour.transparentMaroon)
+                    .foregroundColor(Color.PresetColour.red)
+                    .fontWeight(.semibold)
+                    .cornerRadius(12)
+            }
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        let user = UserMock.userJimHalpert
+        let recentTracks = [TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor]
+        let topTracks = [TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor]
+        let topArtists = [ArtistMock.zachBryan, ArtistMock.jonBellion, ArtistMock.oliviaRodrigo, ArtistMock.kaceyMusgraves]
+        
+        ProfileView(profile: user.spotifyProfile, recentTracks: recentTracks, topTracks: topTracks, topArtists: topArtists)
+            .environmentObject(AuthorizationViewModel())
+            .environmentObject(FriendActivityViewModel(user: user, friendActivites: []))
+    }
+}

--- a/spoti-friends/src/profile/views/ViewMoreRecentTracks.swift
+++ b/spoti-friends/src/profile/views/ViewMoreRecentTracks.swift
@@ -1,63 +1,63 @@
-//import SwiftUI
-//
-///// A SwiftUI view that displays a user's recent songs.
-///// This view is part of a navigation stack and shows a scrollable list of tracks.
-/////
-///// - Parameters:
-/////   - profile: The Spotify Profile to show the data for.
-/////
-//struct ViewMoreRecentTracks: View {
-//    let profile: SpotifyProfile
-//    @State private var recentTracks: ProfileViewModel.TracksWithResponseMetadata
-//    @EnvironmentObject private var profileViewModel: ProfileViewModel
-//    
-//    init(profile: SpotifyProfile, recentTracks: [Track] = []) {
-//        self.profile = profile
-//        self.recentTracks = ProfileViewModel.TracksWithResponseMetadata(tracks: recentTracks)
-//    }
-//    
-//    var body: some View {
-//        ScrollView {
-//            VStack(alignment: .leading) {
-//                Text("Recent Songs")
-//                    .foregroundStyle(Color.PresetColour.whitePrimary)
-//                    .font(.title2)
-//                TrackList(tracks: recentTracks.tracks)
-//            }
-//            .frame(maxWidth: .infinity, alignment: .leading)
-//            .padding(.horizontal, 20)
-//        }
-//        .background(Color.PresetColour.darkgrey)
-//        .toolbarBackground(Color.PresetColour.darkgrey, for: .navigationBar)
-//        .onAppear {
-//            Task {
-//                let response = await profileViewModel.viewMoreForCurrentUser(forItem: .recentTracks)
-//                switch response {
-//                case .tracks(let tracksWithMetadata):
-//                    recentTracks = tracksWithMetadata ?? ProfileViewModel.TracksWithResponseMetadata(tracks: [])
-//                default:
-//                    // It should not end up in this case.
-//                    recentTracks = ProfileViewModel.TracksWithResponseMetadata(tracks: [])
-//                }
-//            }
-//        }
-//    }
-//}
-//
-//#Preview {
-//    ZStack {
-//        let user = UserMock.userJimHalpert
-//        let profile = SpotifyProfileMock.jimHalpert
-//        let recentTracks = [
-//            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
-//            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
-//            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
-//            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
-//            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
-//            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
-//            TrackMock.iRememberEverything, TrackMock.luxury
-//        ]
-//        ViewMoreRecentTracks(profile: profile, recentTracks: recentTracks)
-//            .environmentObject(ProfileViewModel(user: user))
-//    }
-//}
+import SwiftUI
+
+/// A SwiftUI view that displays a user's recent songs.
+/// This view is part of a navigation stack and shows a scrollable list of tracks.
+///
+/// - Parameters:
+///   - profile: The Spotify Profile to show the data for.
+///
+struct ViewMoreRecentTracks: View {
+    let profile: SpotifyProfile
+    @State private var recentTracks: ProfileViewModel.TracksWithResponseMetadata
+    @EnvironmentObject private var profileViewModel: ProfileViewModel
+    
+    init(profile: SpotifyProfile, recentTracks: [Track] = []) {
+        self.profile = profile
+        self.recentTracks = ProfileViewModel.TracksWithResponseMetadata(tracks: recentTracks)
+    }
+    
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading) {
+                Text("Recent Songs")
+                    .foregroundStyle(Color.PresetColour.whitePrimary)
+                    .font(.title2)
+                TrackList(tracks: recentTracks.tracks)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 20)
+        }
+        .background(Color.PresetColour.darkgrey)
+        .toolbarBackground(Color.PresetColour.darkgrey, for: .navigationBar)
+        .onAppear {
+            Task {
+                let response = await profileViewModel.viewMoreForCurrentUser(forItem: .recentTracks)
+                switch response {
+                case .tracks(let tracksWithMetadata):
+                    recentTracks = tracksWithMetadata ?? ProfileViewModel.TracksWithResponseMetadata(tracks: [])
+                default:
+                    // It should not end up in this case.
+                    recentTracks = ProfileViewModel.TracksWithResponseMetadata(tracks: [])
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        let user = UserMock.userJimHalpert
+        let profile = SpotifyProfileMock.jimHalpert
+        let recentTracks = [
+            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+            TrackMock.iRememberEverything, TrackMock.luxury
+        ]
+        ViewMoreRecentTracks(profile: profile, recentTracks: recentTracks)
+            .environmentObject(ProfileViewModel(user: user))
+    }
+}

--- a/spoti-friends/src/profile/views/ViewMoreTopArtists.swift
+++ b/spoti-friends/src/profile/views/ViewMoreTopArtists.swift
@@ -1,84 +1,84 @@
-//import SwiftUI
-//
-///// A SwiftUI view that displays a user's top artists.
-///// This view is part of a navigation stack and shows a scrollable list of artists.
-/////
-///// - Parameters:
-/////   - profile: The Spotify Profile to show the data for.
-/////   - topArtists: The top artists for this profile fro the `selectedTimeRange`.
-/////   - selectedTimeRange: The time range to fetch the top artists data for (one month, six months, one year)
-/////
-//struct ViewMoreTopArtists: View {
-//    let profile: SpotifyProfile
-//    @State private var topArtists: ProfileViewModel.ArtistsWithResponseMetadata
-//    @State private var selectedTimeRange: ProfileViewModel.TimeRange = .oneMonth
-//    @EnvironmentObject private var profileViewModel: ProfileViewModel
-//    
-//    init(profile: SpotifyProfile, topArtists: [Artist] = []) {
-//        self.profile = profile
-//        self.topArtists = ProfileViewModel.ArtistsWithResponseMetadata(artists: topArtists)
-//    }
-//    
-//    var body: some View {
-//        ScrollView {
-//            VStack(alignment: .leading) {
-//                Text("Top Artists")
-//                    .foregroundStyle(Color.PresetColour.whitePrimary)
-//                    .font(.title2)
-//                
-//                HStack {
-//                    Spacer()
-//                    TimeRangeSelector(selectedTimeRange: $selectedTimeRange)
-//                    Spacer()
-//                }
-//                .padding(.vertical, 8)
-//                
-//                ArtistList(artists: topArtists.artists, showItemNumbers: true)
-//            }
-//            .frame(maxWidth: .infinity, alignment: .leading)
-//            .padding(.horizontal, 20)
-//        }
-//        .background(Color.PresetColour.darkgrey)
-//        .toolbarBackground(Color.PresetColour.darkgrey, for: .navigationBar)
-//        .onAppear {
-//            Task {
-//                let response = await profileViewModel.viewMoreForCurrentUser(forItem: .topArtists)
-//                switch response {
-//                case .artists(let artistsWithMetadata):
-//                    topArtists = artistsWithMetadata ?? ProfileViewModel.ArtistsWithResponseMetadata(artists: [])
-//                default:
-//                    // It should not end up in this case.
-//                    topArtists = ProfileViewModel.ArtistsWithResponseMetadata(artists: [])
-//                }
-//            }
-//        }
-//        .onChange(of: selectedTimeRange) {
-//            Task {
-//                let response = await profileViewModel.viewMoreForCurrentUser(forItem: .topArtists, timeRange: selectedTimeRange)
-//                switch response {
-//                case .artists(let artistsWithMetadata):
-//                    topArtists = artistsWithMetadata ?? ProfileViewModel.ArtistsWithResponseMetadata(artists: [])
-//                default:
-//                    // It should not end up in this case.
-//                    topArtists = ProfileViewModel.ArtistsWithResponseMetadata(artists: [])
-//                }
-//            }
-//        }
-//    }
-//}
-//
-//#Preview {
-//    ZStack {
-//        let user = UserMock.userJimHalpert
-//        let profile = SpotifyProfileMock.jimHalpert
-//        let topArtists = [
-//            ArtistMock.jonBellion, ArtistMock.kaceyMusgraves, ArtistMock.oliviaRodrigo, ArtistMock.zachBryan,
-//            ArtistMock.jonBellion, ArtistMock.kaceyMusgraves, ArtistMock.oliviaRodrigo, ArtistMock.zachBryan,
-//            ArtistMock.jonBellion, ArtistMock.kaceyMusgraves, ArtistMock.oliviaRodrigo, ArtistMock.zachBryan,
-//            ArtistMock.jonBellion, ArtistMock.kaceyMusgraves, ArtistMock.oliviaRodrigo, ArtistMock.zachBryan,
-//            ArtistMock.jonBellion, ArtistMock.kaceyMusgraves, ArtistMock.oliviaRodrigo, ArtistMock.zachBryan
-//        ]
-//        ViewMoreTopArtists(profile: profile, topArtists: topArtists)
-//            .environmentObject(ProfileViewModel(user: user))
-//    }
-//}
+import SwiftUI
+
+/// A SwiftUI view that displays a user's top artists.
+/// This view is part of a navigation stack and shows a scrollable list of artists.
+///
+/// - Parameters:
+///   - profile: The Spotify Profile to show the data for.
+///   - topArtists: The top artists for this profile fro the `selectedTimeRange`.
+///   - selectedTimeRange: The time range to fetch the top artists data for (one month, six months, one year)
+///
+struct ViewMoreTopArtists: View {
+    let profile: SpotifyProfile
+    @State private var topArtists: ProfileViewModel.ArtistsWithResponseMetadata
+    @State private var selectedTimeRange: ProfileViewModel.TimeRange = .oneMonth
+    @EnvironmentObject private var profileViewModel: ProfileViewModel
+    
+    init(profile: SpotifyProfile, topArtists: [Artist] = []) {
+        self.profile = profile
+        self.topArtists = ProfileViewModel.ArtistsWithResponseMetadata(artists: topArtists)
+    }
+    
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading) {
+                Text("Top Artists")
+                    .foregroundStyle(Color.PresetColour.whitePrimary)
+                    .font(.title2)
+                
+                HStack {
+                    Spacer()
+                    TimeRangeSelector(selectedTimeRange: $selectedTimeRange)
+                    Spacer()
+                }
+                .padding(.vertical, 8)
+                
+                ArtistList(artists: topArtists.artists, showItemNumbers: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 20)
+        }
+        .background(Color.PresetColour.darkgrey)
+        .toolbarBackground(Color.PresetColour.darkgrey, for: .navigationBar)
+        .onAppear {
+            Task {
+                let response = await profileViewModel.viewMoreForCurrentUser(forItem: .topArtists)
+                switch response {
+                case .artists(let artistsWithMetadata):
+                    topArtists = artistsWithMetadata ?? ProfileViewModel.ArtistsWithResponseMetadata(artists: [])
+                default:
+                    // It should not end up in this case.
+                    topArtists = ProfileViewModel.ArtistsWithResponseMetadata(artists: [])
+                }
+            }
+        }
+        .onChange(of: selectedTimeRange) {
+            Task {
+                let response = await profileViewModel.viewMoreForCurrentUser(forItem: .topArtists, timeRange: selectedTimeRange)
+                switch response {
+                case .artists(let artistsWithMetadata):
+                    topArtists = artistsWithMetadata ?? ProfileViewModel.ArtistsWithResponseMetadata(artists: [])
+                default:
+                    // It should not end up in this case.
+                    topArtists = ProfileViewModel.ArtistsWithResponseMetadata(artists: [])
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        let user = UserMock.userJimHalpert
+        let profile = SpotifyProfileMock.jimHalpert
+        let topArtists = [
+            ArtistMock.jonBellion, ArtistMock.kaceyMusgraves, ArtistMock.oliviaRodrigo, ArtistMock.zachBryan,
+            ArtistMock.jonBellion, ArtistMock.kaceyMusgraves, ArtistMock.oliviaRodrigo, ArtistMock.zachBryan,
+            ArtistMock.jonBellion, ArtistMock.kaceyMusgraves, ArtistMock.oliviaRodrigo, ArtistMock.zachBryan,
+            ArtistMock.jonBellion, ArtistMock.kaceyMusgraves, ArtistMock.oliviaRodrigo, ArtistMock.zachBryan,
+            ArtistMock.jonBellion, ArtistMock.kaceyMusgraves, ArtistMock.oliviaRodrigo, ArtistMock.zachBryan
+        ]
+        ViewMoreTopArtists(profile: profile, topArtists: topArtists)
+            .environmentObject(ProfileViewModel(user: user))
+    }
+}

--- a/spoti-friends/src/profile/views/ViewMoreTopSongs.swift
+++ b/spoti-friends/src/profile/views/ViewMoreTopSongs.swift
@@ -1,86 +1,86 @@
-//import SwiftUI
-//
-///// A SwiftUI view that displays a user's top songs.
-///// This view is part of a navigation stack and shows a scrollable list of tracks.
-/////
-///// - Parameters:
-/////   - profile: The Spotify Profile to show the data for.
-/////   - topTracks: The top tracks for this profile fro the `selectedTimeRange`.
-/////   - selectedTimeRange: The time range to fetch the top tracks data for (one month, six months, one year)
-/////
-//struct ViewMoreTopSongs: View {
-//    let profile: SpotifyProfile
-//    @State private var topTracks: ProfileViewModel.TracksWithResponseMetadata
-//    @State private var selectedTimeRange: ProfileViewModel.TimeRange = .oneMonth
-//    @EnvironmentObject private var profileViewModel: ProfileViewModel
-//    
-//    init(profile: SpotifyProfile, topTracks: [Track] = []) {
-//        self.profile = profile
-//        self.topTracks = ProfileViewModel.TracksWithResponseMetadata(tracks: topTracks)
-//    }
-//    
-//    var body: some View {
-//        ScrollView {
-//            VStack(alignment: .leading) {
-//                Text("Top Songs")
-//                    .foregroundStyle(Color.PresetColour.whitePrimary)
-//                    .font(.title2)
-//                
-//                HStack {
-//                    Spacer()
-//                    TimeRangeSelector(selectedTimeRange: $selectedTimeRange)
-//                    Spacer()
-//                }
-//                .padding(.vertical, 8)
-//                
-//                TrackList(tracks: topTracks.tracks, showItemNumbers: true)
-//            }
-//            .frame(maxWidth: .infinity, alignment: .leading)
-//            .padding(.horizontal, 20)
-//        }
-//        .background(Color.PresetColour.darkgrey)
-//        .toolbarBackground(Color.PresetColour.darkgrey, for: .navigationBar)
-//        .onAppear {
-//            Task {
-//                let response = await profileViewModel.viewMoreForCurrentUser(forItem: .topTracks)
-//                switch response {
-//                case .tracks(let tracksWithMetadata):
-//                    topTracks = tracksWithMetadata ?? ProfileViewModel.TracksWithResponseMetadata(tracks: [])
-//                default:
-//                    // It should not end up in this case.
-//                    topTracks = ProfileViewModel.TracksWithResponseMetadata(tracks: [])
-//                }
-//            }
-//        }
-//        .onChange(of: selectedTimeRange) {
-//            Task {
-//                let response = await profileViewModel.viewMoreForCurrentUser(forItem: .topTracks, timeRange: selectedTimeRange)
-//                switch response {
-//                case .tracks(let tracksWithMetadata):
-//                    topTracks = tracksWithMetadata ?? ProfileViewModel.TracksWithResponseMetadata(tracks: [])
-//                default:
-//                    // It should not end up in this case.
-//                    topTracks = ProfileViewModel.TracksWithResponseMetadata(tracks: [])
-//                }
-//            }
-//        }
-//    }
-//}
-//
-//#Preview {
-//    ZStack {
-//        let user = UserMock.userJimHalpert
-//        let profile = SpotifyProfileMock.jimHalpert
-//        let topTracks = [
-//            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
-//            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
-//            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
-//            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
-//            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
-//            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
-//            TrackMock.iRememberEverything, TrackMock.luxury
-//        ]
-//        ViewMoreTopSongs(profile: profile, topTracks: topTracks)
-//            .environmentObject(ProfileViewModel(user: user))
-//    }
-//}
+import SwiftUI
+
+/// A SwiftUI view that displays a user's top songs.
+/// This view is part of a navigation stack and shows a scrollable list of tracks.
+///
+/// - Parameters:
+///   - profile: The Spotify Profile to show the data for.
+///   - topTracks: The top tracks for this profile fro the `selectedTimeRange`.
+///   - selectedTimeRange: The time range to fetch the top tracks data for (one month, six months, one year)
+///
+struct ViewMoreTopSongs: View {
+    let profile: SpotifyProfile
+    @State private var topTracks: ProfileViewModel.TracksWithResponseMetadata
+    @State private var selectedTimeRange: ProfileViewModel.TimeRange = .oneMonth
+    @EnvironmentObject private var profileViewModel: ProfileViewModel
+    
+    init(profile: SpotifyProfile, topTracks: [Track] = []) {
+        self.profile = profile
+        self.topTracks = ProfileViewModel.TracksWithResponseMetadata(tracks: topTracks)
+    }
+    
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading) {
+                Text("Top Songs")
+                    .foregroundStyle(Color.PresetColour.whitePrimary)
+                    .font(.title2)
+                
+                HStack {
+                    Spacer()
+                    TimeRangeSelector(selectedTimeRange: $selectedTimeRange)
+                    Spacer()
+                }
+                .padding(.vertical, 8)
+                
+                TrackList(tracks: topTracks.tracks, showItemNumbers: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 20)
+        }
+        .background(Color.PresetColour.darkgrey)
+        .toolbarBackground(Color.PresetColour.darkgrey, for: .navigationBar)
+        .onAppear {
+            Task {
+                let response = await profileViewModel.viewMoreForCurrentUser(forItem: .topTracks)
+                switch response {
+                case .tracks(let tracksWithMetadata):
+                    topTracks = tracksWithMetadata ?? ProfileViewModel.TracksWithResponseMetadata(tracks: [])
+                default:
+                    // It should not end up in this case.
+                    topTracks = ProfileViewModel.TracksWithResponseMetadata(tracks: [])
+                }
+            }
+        }
+        .onChange(of: selectedTimeRange) {
+            Task {
+                let response = await profileViewModel.viewMoreForCurrentUser(forItem: .topTracks, timeRange: selectedTimeRange)
+                switch response {
+                case .tracks(let tracksWithMetadata):
+                    topTracks = tracksWithMetadata ?? ProfileViewModel.TracksWithResponseMetadata(tracks: [])
+                default:
+                    // It should not end up in this case.
+                    topTracks = ProfileViewModel.TracksWithResponseMetadata(tracks: [])
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        let user = UserMock.userJimHalpert
+        let profile = SpotifyProfileMock.jimHalpert
+        let topTracks = [
+            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+            TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+            TrackMock.iRememberEverything, TrackMock.luxury
+        ]
+        ViewMoreTopSongs(profile: profile, topTracks: topTracks)
+            .environmentObject(ProfileViewModel(user: user))
+    }
+}

--- a/spoti-friends/src/spotify/models/Album/Album.swift
+++ b/spoti-friends/src/spotify/models/Album/Album.swift
@@ -19,11 +19,11 @@ class Album: SpotifyResource, Codable {
         self.image = image
     }
     
-//    convenience required init(from decoder: any Decoder) throws {
-//        self.init()
-//        let container = try decoder.container(keyedBy: CodingKeys.self)
-//        self.spotifyUri = try container.decode(String.self, forKey: .spotifyUri)
-//        self.name = try container.decode(String.self, forKey: .name)
-//        self.image = decodeAndExtractFirstSpotifyImageURL(from: container, forKey: .image)
-//    }
+    /// Custom initializer for decoding from Spotify API
+    required init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.spotifyUri = try container.decode(String.self, forKey: .spotifyUri)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.image = decodeAndExtractFirstSpotifyImageURL(from: container, forKey: .image)
+    }
 }

--- a/spoti-friends/src/spotify/models/Artist/Artist.swift
+++ b/spoti-friends/src/spotify/models/Artist/Artist.swift
@@ -22,12 +22,12 @@ class Artist: SpotifyResource, Codable {
         self.image = image
     }
     
-//    convenience required init(from decoder: any Decoder) throws {
-//        self.init()
-//        let container = try decoder.container(keyedBy: CodingKeys.self)
-//        self.spotifyUri = try container.decode(String.self, forKey: .spotifyUri)
-//        self.name = try container.decode(String.self, forKey: .name)
-//        self.genres = try container.decodeIfPresent(List<String>.self, forKey: .genres) ?? List<String>()
-//        self.image = decodeAndExtractFirstSpotifyImageURL(from: container, forKey: .image)
-//    }
+    /// Custom initializer for decoding from Spotify API
+    required init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.spotifyUri = try container.decode(String.self, forKey: .spotifyUri)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.genres = try container.decodeIfPresent([String].self, forKey: .genres) ?? []
+        self.image = decodeAndExtractFirstSpotifyImageURL(from: container, forKey: .image)
+    }
 }

--- a/spoti-friends/src/spotify/models/Track/Track.swift
+++ b/spoti-friends/src/spotify/models/Track/Track.swift
@@ -6,7 +6,7 @@ class Track: SpotifyResource, Codable {
     let name: String
     let artists: [Artist]
     let album: Album
-    let context: TrackContext
+    let context: TrackContext?
     
     /// Mapping of the Swift object properties to the Spotify Web API response JSON keys.
     enum CodingKeys: String, CodingKey {
@@ -17,7 +17,7 @@ class Track: SpotifyResource, Codable {
         case context
     }
     
-    init(spotifyUri: String, name: String, artists: [Artist], album: Album, context: TrackContext) {
+    init(spotifyUri: String, name: String, artists: [Artist], album: Album, context: TrackContext? = nil) {
         self.spotifyUri = spotifyUri
         self.name = name
         self.artists = artists
@@ -25,14 +25,14 @@ class Track: SpotifyResource, Codable {
         self.context = context
     }
     
-//    convenience required init(from decoder: any Decoder) throws {
-//        let container = try decoder.container(keyedBy: CodingKeys.self)
-//        
-//        let spotifyUri = try container.decodeIfPresent(String.self, forKey: .spotifyUri) ?? ""
-//        let name = try container.decode(String.self, forKey: .name)
-//        let artists = try container.decode([Artist].self, forKey: .artists)
-//        let album = try container.decode(Album.self, forKey: .album)
-//        
-//        self.init(spotifyUri: spotifyUri, name: name, artists: artists, album: album, context: context)
-//    }
+    /// Custom initializer for decoding from Spotify API
+    required init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        self.spotifyUri = try container.decodeIfPresent(String.self, forKey: .spotifyUri) ?? ""
+        self.name = try container.decode(String.self, forKey: .name)
+        self.artists = try container.decode([Artist].self, forKey: .artists)
+        self.album = try container.decode(Album.self, forKey: .album)
+        self.context = try container.decodeIfPresent(TrackContext.self, forKey: .context)
+    }
 }


### PR DESCRIPTION
#### Changes
- Fixed the classes and decoding for the profile feature related code
- Marked `track.context` to be optional
  - A context only exists when the track was played from a certain place (or context)
  - A track can exist in and of itself, without the need for a `context` if it is not being played
- Uncommented out all of the profile data related views
