### PR TITLE
FM-112 Created frontend for received and sent views

### DIFF
--- a/spoti-friends.xcodeproj/project.pbxproj
+++ b/spoti-friends.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		CB3B617F2C1BDFB00088DFA1 /* PageTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3B617E2C1BDFB00088DFA1 /* PageTitle.swift */; };
 		CB3B61812C1F83AE0088DFA1 /* AuthenticatedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3B61802C1F83AE0088DFA1 /* AuthenticatedView.swift */; };
 		CB454D2D2CC8C73E00AE41D5 /* NonUserProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB454D2C2CC8C73E00AE41D5 /* NonUserProfileView.swift */; };
+		CB4AF9A62CFD330B005AE716 /* SongShareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4AF9A52CFD330B005AE716 /* SongShareView.swift */; };
+		CB4AF9A82CFEB875005AE716 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4AF9A72CFEB875005AE716 /* SearchBar.swift */; };
 		CB59BCB52C2FA08D0061C99B /* ListeningActivityCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB59BCB42C2FA08D0061C99B /* ListeningActivityCard.swift */; };
 		CB59BCB72C2FAB890061C99B /* ProfileImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB59BCB62C2FAB890061C99B /* ProfileImage.swift */; };
 		CB59BCBF2C2FAFB30061C99B /* ImageWithSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB59BCBE2C2FAFB30061C99B /* ImageWithSpecs.swift */; };
@@ -130,6 +132,8 @@
 		CB3B617E2C1BDFB00088DFA1 /* PageTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageTitle.swift; sourceTree = "<group>"; };
 		CB3B61802C1F83AE0088DFA1 /* AuthenticatedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedView.swift; sourceTree = "<group>"; };
 		CB454D2C2CC8C73E00AE41D5 /* NonUserProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonUserProfileView.swift; sourceTree = "<group>"; };
+		CB4AF9A52CFD330B005AE716 /* SongShareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SongShareView.swift; sourceTree = "<group>"; };
+		CB4AF9A72CFEB875005AE716 /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
 		CB59BCB42C2FA08D0061C99B /* ListeningActivityCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningActivityCard.swift; sourceTree = "<group>"; };
 		CB59BCB62C2FAB890061C99B /* ProfileImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImage.swift; sourceTree = "<group>"; };
 		CB59BCBE2C2FAFB30061C99B /* ImageWithSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageWithSpecs.swift; sourceTree = "<group>"; };
@@ -405,6 +409,23 @@
 			path = lists;
 			sourceTree = "<group>";
 		};
+		CB4AF9A32CFD3291005AE716 /* song-sharing */ = {
+			isa = PBXGroup;
+			children = (
+				CB4AF9A42CFD32E1005AE716 /* views */,
+			);
+			path = "song-sharing";
+			sourceTree = "<group>";
+		};
+		CB4AF9A42CFD32E1005AE716 /* views */ = {
+			isa = PBXGroup;
+			children = (
+				CB4AF9A52CFD330B005AE716 /* SongShareView.swift */,
+				CB4AF9A72CFEB875005AE716 /* SearchBar.swift */,
+			);
+			path = views;
+			sourceTree = "<group>";
+		};
 		CB59BCB22C2F9EF20061C99B /* views */ = {
 			isa = PBXGroup;
 			children = (
@@ -583,8 +604,9 @@
 		CB9A9ADD2C0BEC170073817C /* src */ = {
 			isa = PBXGroup;
 			children = (
-				CB6A5D892CA684BD0063A757 /* database */,
+				CB4AF9A32CFD3291005AE716 /* song-sharing */,
 				CB9A9AAA2C0BB13E0073817C /* spotifriendsApp.swift */,
+				CB6A5D892CA684BD0063A757 /* database */,
 				CB9A9ADE2C0C22620073817C /* auth */,
 				CB0854C02C14F5250088E87D /* common */,
 				CB7C05A62C0EB8F0001A0062 /* friendActivity */,
@@ -718,6 +740,7 @@
 				CB3797F72CA7EB82009F5D56 /* AppwriteUserService.swift in Sources */,
 				CB8D3C2E2C0D28C000C493E8 /* CodeChallenge.swift in Sources */,
 				CB7C05B52C1191EC001A0062 /* UnauthenticatedView.swift in Sources */,
+				CB4AF9A82CFEB875005AE716 /* SearchBar.swift in Sources */,
 				CB875CB92C3524B4001B364D /* TrackMock.swift in Sources */,
 				CB7C05B32C1191BA001A0062 /* AuthorizationDeniedView.swift in Sources */,
 				CB59BCB72C2FAB890061C99B /* ProfileImage.swift in Sources */,
@@ -755,6 +778,7 @@
 				CB3724972C3B27CA004883D1 /* ProfileDetails.swift in Sources */,
 				CB6A5D8C2CA684F10063A757 /* Appwrite.swift in Sources */,
 				CB0854BC2C14D58E0088E87D /* AuthorizationWebView.swift in Sources */,
+				CB4AF9A62CFD330B005AE716 /* SongShareView.swift in Sources */,
 				CB70E8A52C838FB400F9A197 /* SomethingWentWrongView.swift in Sources */,
 				CB70E8A02C8017CD00F9A197 /* ArtistList.swift in Sources */,
 				CB0B93762C771C04003A9720 /* TrackContext.swift in Sources */,

--- a/spoti-friends.xcodeproj/project.pbxproj
+++ b/spoti-friends.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		CB0B93782C771C23003A9720 /* Artist.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0B93772C771C21003A9720 /* Artist.swift */; };
 		CB0B937F2C771D5D003A9720 /* CurrentOrMostRecentTrackMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0B937E2C771D5A003A9720 /* CurrentOrMostRecentTrackMock.swift */; };
 		CB0E59262CEA5B0B003B30D7 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0E59252CEA5B0B003B30D7 /* ProfileView.swift */; };
+		CB2FCB982CFEED510012FF0F /* TrackDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2FCB972CFEED510012FF0F /* TrackDetailsView.swift */; };
+		CB2FCB9A2CFEEE360012FF0F /* TrackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2FCB992CFEEE360012FF0F /* TrackView.swift */; };
 		CB3417FB2C180D3D00BE70A8 /* SpotifyAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3417FA2C180D3D00BE70A8 /* SpotifyAPIError.swift */; };
 		CB3417FF2C1BDBC800BE70A8 /* UserProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3417FE2C1BDBC800BE70A8 /* UserProfileView.swift */; };
 		CB3724972C3B27CA004883D1 /* ProfileDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3724962C3B27CA004883D1 /* ProfileDetails.swift */; };
@@ -120,6 +122,8 @@
 		CB0B93772C771C21003A9720 /* Artist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Artist.swift; sourceTree = "<group>"; };
 		CB0B937E2C771D5A003A9720 /* CurrentOrMostRecentTrackMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentOrMostRecentTrackMock.swift; sourceTree = "<group>"; };
 		CB0E59252CEA5B0B003B30D7 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
+		CB2FCB972CFEED510012FF0F /* TrackDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackDetailsView.swift; sourceTree = "<group>"; };
+		CB2FCB992CFEEE360012FF0F /* TrackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackView.swift; sourceTree = "<group>"; };
 		CB3417FA2C180D3D00BE70A8 /* SpotifyAPIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotifyAPIError.swift; sourceTree = "<group>"; };
 		CB3417FE2C1BDBC800BE70A8 /* UserProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileView.swift; sourceTree = "<group>"; };
 		CB3724962C3B27CA004883D1 /* ProfileDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDetails.swift; sourceTree = "<group>"; };
@@ -324,6 +328,15 @@
 			path = utils;
 			sourceTree = "<group>";
 		};
+		CB2FCB942CFEED1D0012FF0F /* Track */ = {
+			isa = PBXGroup;
+			children = (
+				CB2FCB972CFEED510012FF0F /* TrackDetailsView.swift */,
+				CB2FCB992CFEEE360012FF0F /* TrackView.swift */,
+			);
+			path = Track;
+			sourceTree = "<group>";
+		};
 		CB3417F72C17FC1800BE70A8 /* helpers */ = {
 			isa = PBXGroup;
 			children = (
@@ -440,6 +453,7 @@
 		CB59BCBB2C2FAED50061C99B /* views */ = {
 			isa = PBXGroup;
 			children = (
+				CB2FCB942CFEED1D0012FF0F /* Track */,
 				CB59BCBE2C2FAFB30061C99B /* ImageWithSpecs.swift */,
 				CB59BCB62C2FAB890061C99B /* ProfileImage.swift */,
 			);
@@ -731,6 +745,8 @@
 				CB875CAE2C31507E001B364D /* FriendActivityViewModel.swift in Sources */,
 				CB9A9AE02C0C22D70073817C /* SpotifyAuth.swift in Sources */,
 				CB59BCD02C30FA360061C99B /* RotatingSyncIcon.swift in Sources */,
+				CB2FCB9A2CFEEE360012FF0F /* TrackView.swift in Sources */,
+				CB2FCB982CFEED510012FF0F /* TrackDetailsView.swift in Sources */,
 				CB7087562CAB68F700FE97C7 /* ProfileServiceManager.swift in Sources */,
 				CBB1A3D02C933EBA00D3D658 /* TimeRangeSelector.swift in Sources */,
 				CBC75F522C3673DF00442795 /* TimeUtils.swift in Sources */,

--- a/spoti-friends/src/common/views/AuthenticatedView.swift
+++ b/spoti-friends/src/common/views/AuthenticatedView.swift
@@ -28,6 +28,11 @@ struct AuthenticatedView: View {
             }
             .environmentObject(friendActivityViewModel)
             .environmentObject(profileViewModel)
+            
+            SongShareView().tabItem {
+                Label("Share", systemImage: "square.and.arrow.up")
+            }
+            
             ProfileView(profile: friendActivityViewModel.user?.spotifyProfile ?? SpotifyProfileMock.jimHalpert).tabItem {
                 Label("My Profile", systemImage: "person")
             }

--- a/spoti-friends/src/common/views/PageTitle.swift
+++ b/spoti-friends/src/common/views/PageTitle.swift
@@ -13,7 +13,6 @@ struct PageTitle: View {
             
             Spacer()
         }
-//        .padding()
         .padding(.leading, 8)
     }
 }

--- a/spoti-friends/src/common/views/PageTitle.swift
+++ b/spoti-friends/src/common/views/PageTitle.swift
@@ -13,7 +13,7 @@ struct PageTitle: View {
             
             Spacer()
         }
-        .padding()
+//        .padding()
         .padding(.leading, 8)
     }
 }

--- a/spoti-friends/src/friendActivity/views/FriendActivityView.swift
+++ b/spoti-friends/src/friendActivity/views/FriendActivityView.swift
@@ -33,7 +33,6 @@ struct FriendActivityView: View {
                                     .environmentObject(friendActivityViewModel)
                             }
                         }
-                        .padding()
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                     }
                 }
@@ -46,6 +45,7 @@ struct FriendActivityView: View {
                     try? await friendActivityViewModel.setFriendActivity()
                 }
             }
+            .padding()
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Color.PresetColour.darkgrey)
         }
@@ -59,5 +59,6 @@ struct FriendActivityView: View {
         
         FriendActivityView()
             .environmentObject(FriendActivityViewModel(user: user, friendActivites: activities))
+            .environmentObject(ProfileViewModel(user: user))
     }
 }

--- a/spoti-friends/src/profile/views/NonUserProfileView.swift
+++ b/spoti-friends/src/profile/views/NonUserProfileView.swift
@@ -34,6 +34,7 @@ struct NonUserProfileView: View {
             Spacer()
         }
         .padding(.top)
+        .padding(.horizontal, 20)
     }
 }
 

--- a/spoti-friends/src/profile/views/ProfileView.swift
+++ b/spoti-friends/src/profile/views/ProfileView.swift
@@ -31,7 +31,6 @@ struct ProfileView: View {
                 }
             }
             .frame(minHeight: reader.size.height)
-            .padding(.horizontal, 20)
         }
         .background(Color.PresetGradient.profileViewGradient(profile: profile))
         .onAppear {

--- a/spoti-friends/src/profile/views/UserProfileView.swift
+++ b/spoti-friends/src/profile/views/UserProfileView.swift
@@ -98,6 +98,7 @@ struct UserProfileView: View {
                     }
                     Spacer()
                 }
+                .padding(.horizontal, 20)
                 .onAppear {
                     Task {
                         // Comment out these lines for SwiftUI Previews

--- a/spoti-friends/src/profile/views/lists/TrackList.swift
+++ b/spoti-friends/src/profile/views/lists/TrackList.swift
@@ -36,36 +36,13 @@ struct TrackList: View {
                                     .frame(width: 20)
                                     .padding(.trailing, 2)
                             }
-                            ImageWithSpecs(imageUrl: track.album.image, width: 36, height: 36, cornerRadius: 2)
                             
-                            VStack (alignment: .leading) {
-                                // Track name
-                                Text(track.name)
-                                    .font(.callout)
-                                    .foregroundStyle(Color.PresetColour.whitePrimary)
-                                    .lineLimit(1)
-                                
-                                // Artist names
-                                HStack(spacing: 0) {
-                                    let artistsArray = Array(track.artists) // Convert List<Artist> to [Artist]
-                                    ForEach(artistsArray.indices, id: \.self) { index in
-                                        let artist = artistsArray[index]
-                                        
-                                        Text(index < artistsArray.count - 1
-                                             ? "\(artist.name), "
-                                             : artist.name)
-                                        .font(.footnote)
-                                        .foregroundStyle(Color.PresetColour.whiteSecondary)
-                                    }
-                                }
-                                .lineLimit(1)
-                            }
+                            TrackView(track: track)
                             
                             Spacer() // To left align the content
                         }
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 4)
-//                        .animation(.easeInOut(duration: 0.6), value: tracks)
                     }
                 }
             }

--- a/spoti-friends/src/song-sharing/views/SearchBar.swift
+++ b/spoti-friends/src/song-sharing/views/SearchBar.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+struct SearchBar: View {
+    var placeholderText: String
+    @State private var searchText: String = ""
+    @State private var isEditing = false
+    
+    var body: some View {
+        HStack {
+            TextField("",
+                      text: $searchText,
+                      prompt: Text(placeholderText)
+                .foregroundStyle(Color.PresetColour.blackSecondary)
+            )
+            .font(.callout)
+            .padding(.vertical, 12)
+            .padding(.horizontal, 32)
+            .background(Color.PresetColour.whitePrimary)
+            .foregroundStyle(Color.PresetColour.blackSecondary)
+            .cornerRadius(8)
+            .overlay(
+                HStack {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundColor(Color.PresetColour.blackSecondary)
+                        .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
+                        .padding(.leading, 8)
+                    
+                    if isEditing {
+                        Button(action: {
+                            self.searchText = ""
+                        }) {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundColor(.gray)
+                                .padding(.trailing, 8)
+                        }
+                    }
+                }
+            )
+            .padding(.horizontal, 10)
+            .onTapGesture {
+                self.isEditing = true
+            }
+        }
+    }
+}
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            SearchBar(placeholderText: "Search...")
+            Spacer()
+        }
+        .padding()
+    }
+}
+
+struct SearchBar_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/spoti-friends/src/song-sharing/views/SearchBar.swift
+++ b/spoti-friends/src/song-sharing/views/SearchBar.swift
@@ -1,5 +1,14 @@
 import SwiftUI
 
+/// A customizable search bar component.
+///
+/// Displays a text input field with a placeholder, magnifying glass icon on the left,
+/// and a clear button on the right when the user starts typing.
+///
+/// - Parameters:
+///   - placeholderText: The placeholder text displayed in the search bar.
+///
+/// - Returns: A View that renders the search bar.
 struct SearchBar: View {
     var placeholderText: String
     @State private var searchText: String = ""

--- a/spoti-friends/src/song-sharing/views/SongShareView.swift
+++ b/spoti-friends/src/song-sharing/views/SongShareView.swift
@@ -3,8 +3,10 @@ import SwiftUI
 struct SongShareView: View {
     let searchBarPlaceholderText = "What song do you want to share?"
     @State private var selectedTab = 0
+    @State private var receivedTracks: [Track]
+    @State private var sentTracks: [Track]
     
-    init() {
+    init(receivedTracks: [Track] = [], sentTracks: [Track] = []) {
         // Picker background color
         UISegmentedControl.appearance().backgroundColor = UIColor(Color(red: 0.06, green: 0.06, blue: 0.06))
         
@@ -18,6 +20,9 @@ struct SongShareView: View {
         // Picker foreground color of inactive
         UISegmentedControl.appearance().setTitleTextAttributes(
             [.foregroundColor: UIColor(Color.PresetColour.whitePrimary)], for: .normal)
+        
+        self.receivedTracks = receivedTracks
+        self.sentTracks = sentTracks
     }
 
     
@@ -30,11 +35,10 @@ struct SongShareView: View {
             }
             .padding()
             
-            // Tabs
+            // Received/Sent Tab Bar
             ZStack (alignment: .bottom) {
                 Picker("Tabs", selection: $selectedTab) {
                     Text("Received").tag(0)
-                        .font(.headline)
                     Text("Sent").tag(1)
                 }
                 .pickerStyle(.segmented)
@@ -48,21 +52,22 @@ struct SongShareView: View {
             // Horizontal scrollable TabView
             TabView(selection: $selectedTab) {
                 // Received songs tab
-                TrackList(tracks: [])
+                TrackList(tracks: receivedTracks)
                     .tag(0)
                 
                 // Sent songs tab
-                TrackList(tracks: [])
+                TrackList(tracks: sentTracks)
                     .tag(1)
             }
             .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
         }
-//        .padding()
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.PresetColour.darkgrey)
     }
 }
 
 #Preview {
-    SongShareView()
+    let receivedTracks: [Track] = [TrackMock.iRememberEverything]
+    let sentTracks: [Track] = []
+    SongShareView(receivedTracks: receivedTracks, sentTracks: sentTracks)
 }

--- a/spoti-friends/src/song-sharing/views/SongShareView.swift
+++ b/spoti-friends/src/song-sharing/views/SongShareView.swift
@@ -1,16 +1,21 @@
 import SwiftUI
 
+/// A View that allows users to share songs with their friends.
+///
+/// The view contains a search bar to search for songs to share and two scrollable tabs to display
+/// songs received from friends and songs sent to friends.
+///
+/// - Parameters:
+///   - receivedTracks: An array of `Track` objects representing the songs received from friends.
+///   - sentTracks: An array of `Track` objects representing the songs sent to friends.
+///
 struct SongShareView: View {
     let searchBarPlaceholderText = "What song do you want to share?"
     @State private var selectedTab = 0
     @State private var receivedTracks: [Track]
     @State private var sentTracks: [Track]
     
-    init(receivedTracks: [Track] = [TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
-                                    TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
-                                    TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
-                                    TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
-                                    TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor], sentTracks: [Track] = []) {
+    init(receivedTracks: [Track] = [], sentTracks: [Track] = []) {
         // Picker background color
         UISegmentedControl.appearance().backgroundColor = UIColor(Color(red: 0.06, green: 0.06, blue: 0.06))
         
@@ -82,6 +87,6 @@ struct SongShareView: View {
                                    TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
                                    TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
                                    TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor]
-    let sentTracks: [Track] = []
+    let sentTracks: [Track] = [TrackMock.luxury]
     SongShareView(receivedTracks: receivedTracks, sentTracks: sentTracks)
 }

--- a/spoti-friends/src/song-sharing/views/SongShareView.swift
+++ b/spoti-friends/src/song-sharing/views/SongShareView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct SongShareView: View {
+    let searchBarPlaceholderText = "What song do you want to share?"
+    
+    var body: some View {
+        VStack {
+            PageTitle(pageTitle: "Share")
+            
+            // Search bar
+            SearchBar(placeholderText: searchBarPlaceholderText)
+            
+            Spacer()
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.PresetColour.darkgrey)
+    }
+}
+
+#Preview {
+    SongShareView()
+}

--- a/spoti-friends/src/song-sharing/views/SongShareView.swift
+++ b/spoti-friends/src/song-sharing/views/SongShareView.swift
@@ -6,7 +6,11 @@ struct SongShareView: View {
     @State private var receivedTracks: [Track]
     @State private var sentTracks: [Track]
     
-    init(receivedTracks: [Track] = [], sentTracks: [Track] = []) {
+    init(receivedTracks: [Track] = [TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+                                    TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+                                    TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+                                    TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+                                    TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor], sentTracks: [Track] = []) {
         // Picker background color
         UISegmentedControl.appearance().backgroundColor = UIColor(Color(red: 0.06, green: 0.06, blue: 0.06))
         
@@ -52,12 +56,18 @@ struct SongShareView: View {
             // Horizontal scrollable TabView
             TabView(selection: $selectedTab) {
                 // Received songs tab
-                TrackList(tracks: receivedTracks)
-                    .tag(0)
+                ScrollView {
+                    TrackList(tracks: receivedTracks)
+                        .padding(.horizontal)
+                }
+                .tag(0)
                 
                 // Sent songs tab
-                TrackList(tracks: sentTracks)
-                    .tag(1)
+                ScrollView {
+                    TrackList(tracks: sentTracks)
+                        .padding(.horizontal)
+                }
+                .tag(1)
             }
             .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
         }
@@ -67,7 +77,11 @@ struct SongShareView: View {
 }
 
 #Preview {
-    let receivedTracks: [Track] = [TrackMock.iRememberEverything]
+    let receivedTracks: [Track] = [TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+                                   TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+                                   TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+                                   TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor,
+                                   TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor]
     let sentTracks: [Track] = []
     SongShareView(receivedTracks: receivedTracks, sentTracks: sentTracks)
 }

--- a/spoti-friends/src/song-sharing/views/SongShareView.swift
+++ b/spoti-friends/src/song-sharing/views/SongShareView.swift
@@ -2,17 +2,62 @@ import SwiftUI
 
 struct SongShareView: View {
     let searchBarPlaceholderText = "What song do you want to share?"
+    @State private var selectedTab = 0
+    
+    init() {
+        // Picker background color
+        UISegmentedControl.appearance().backgroundColor = UIColor(Color(red: 0.06, green: 0.06, blue: 0.06))
+        
+        // Picker background color of selected
+        UISegmentedControl.appearance().selectedSegmentTintColor = UIColor(Color(red: 0.11, green: 0.11, blue: 0.11))
+        
+        // Picker foreground color of selected
+        UISegmentedControl.appearance().setTitleTextAttributes(
+            [.foregroundColor: UIColor(Color.PresetColour.spotifyGreen)], for: .selected)
+        
+        // Picker foreground color of inactive
+        UISegmentedControl.appearance().setTitleTextAttributes(
+            [.foregroundColor: UIColor(Color.PresetColour.whitePrimary)], for: .normal)
+    }
+
     
     var body: some View {
         VStack {
-            PageTitle(pageTitle: "Share")
+            VStack {
+                PageTitle(pageTitle: "Share")
+                
+                SearchBar(placeholderText: searchBarPlaceholderText)
+            }
+            .padding()
             
-            // Search bar
-            SearchBar(placeholderText: searchBarPlaceholderText)
+            // Tabs
+            ZStack (alignment: .bottom) {
+                Picker("Tabs", selection: $selectedTab) {
+                    Text("Received").tag(0)
+                        .font(.headline)
+                    Text("Sent").tag(1)
+                }
+                .pickerStyle(.segmented)
+                
+                Divider()
+                    .frame(height: 1)
+                    .background(Color.PresetColour.whitePrimary)
+                    .opacity(0.8)
+            }
             
-            Spacer()
+            // Horizontal scrollable TabView
+            TabView(selection: $selectedTab) {
+                // Received songs tab
+                TrackList(tracks: [])
+                    .tag(0)
+                
+                // Sent songs tab
+                TrackList(tracks: [])
+                    .tag(1)
+            }
+            .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
         }
-        .padding()
+//        .padding()
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.PresetColour.darkgrey)
     }

--- a/spoti-friends/src/spotify/views/Track/TrackDetailsView.swift
+++ b/spoti-friends/src/spotify/views/Track/TrackDetailsView.swift
@@ -18,7 +18,7 @@ struct TrackDetailsView: View {
             
             // Artist names
             HStack(spacing: 0) {
-                let artistsArray = Array(track.artists) // Convert List<Artist> to [Artist]
+                let artistsArray = track.artists
                 ForEach(artistsArray.indices, id: \.self) { index in
                     let artist = artistsArray[index]
                     

--- a/spoti-friends/src/spotify/views/Track/TrackDetailsView.swift
+++ b/spoti-friends/src/spotify/views/Track/TrackDetailsView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct TrackDetails: View {
+    let track: Track
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            // Track name
+            Text(track.name)
+                .font(.callout)
+                .foregroundStyle(Color.PresetColour.whitePrimary)
+                .lineLimit(1)
+            
+            // Artist names
+            HStack(spacing: 0) {
+                let artistsArray = Array(track.artists) // Convert List<Artist> to [Artist]
+                ForEach(artistsArray.indices, id: \.self) { index in
+                    let artist = artistsArray[index]
+                    
+                    Text(index < artistsArray.count - 1
+                         ? "\(artist.name), "
+                         : artist.name)
+                    .font(.footnote)
+                    .foregroundStyle(Color.PresetColour.whiteSecondary)
+                }
+            }
+            .lineLimit(1)
+        }
+    }
+}
+
+#Preview {
+    TrackDetails(track: TrackMock.iRememberEverything)
+}

--- a/spoti-friends/src/spotify/views/Track/TrackDetailsView.swift
+++ b/spoti-friends/src/spotify/views/Track/TrackDetailsView.swift
@@ -1,6 +1,11 @@
 import SwiftUI
 
-struct TrackDetails: View {
+/// A View that displays information about a track such as the track name and its artists.
+///
+/// - Parameters:
+///   - track: A `Track` object representing the track to display details for.
+///
+struct TrackDetailsView: View {
     let track: Track
     
     var body: some View {
@@ -30,5 +35,5 @@ struct TrackDetails: View {
 }
 
 #Preview {
-    TrackDetails(track: TrackMock.iRememberEverything)
+    TrackDetailsView(track: TrackMock.iRememberEverything)
 }

--- a/spoti-friends/src/spotify/views/Track/TrackView.swift
+++ b/spoti-friends/src/spotify/views/Track/TrackView.swift
@@ -1,5 +1,10 @@
 import SwiftUI
 
+/// A View that displays a track with its album cover and details.
+///
+/// - Parameters:
+///   - track: A `Track` object representing the track to be displayed.
+///
 struct TrackView: View {
     let track: Track
     
@@ -8,7 +13,7 @@ struct TrackView: View {
             // Album cover
             ImageWithSpecs(imageUrl: track.album.image, width: 36, height: 36, cornerRadius: 2)
             
-            TrackDetails(track: track)
+            TrackDetailsView(track: track)
         }
     }
 }

--- a/spoti-friends/src/spotify/views/Track/TrackView.swift
+++ b/spoti-friends/src/spotify/views/Track/TrackView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct TrackView: View {
+    let track: Track
+    
+    var body: some View {
+        HStack {
+            // Album cover
+            ImageWithSpecs(imageUrl: track.album.image, width: 36, height: 36, cornerRadius: 2)
+            
+            TrackDetails(track: track)
+        }
+    }
+}
+
+#Preview {
+    TrackView(track: TrackMock.iRememberEverything)
+}


### PR DESCRIPTION
#### Changes
- Created a `SongShareView` which displays the "home" view for the song sharing feature
    - This is frontend related changes only
    - Right now it renders a `TrackList`, but will need to create a new class and view for Shared Tracks
        - These may contain additional metadata such as: sender/receiver, listened status, reaction, etc.
- Refactored the Track related views to be composed of several reusable views instead of one large one
- Fixed a padding bug in `ProfileView`