### PR TITLE
FM-141 Mark song as listened

### DIFF
--- a/spoti-friends/src/auth/SpotifyAuth.swift
+++ b/spoti-friends/src/auth/SpotifyAuth.swift
@@ -58,6 +58,7 @@ class SpotifyAuth {
                 return .granted
             }
             
+            MetricsServiceManager.shared.trackUserSignedUp(user: currentUser)
             await ProfileServiceManager.shared.storeProfilePictureLocally(profile: currentUser.spotifyProfile)
             try await UserServiceManager.shared.saveUserToDB(currentUser)
             return .granted

--- a/spoti-friends/src/metrics/MetricsEventEnum.swift
+++ b/spoti-friends/src/metrics/MetricsEventEnum.swift
@@ -10,6 +10,7 @@ enum MetricsEvent: String {
     
     /// An enum to track the various event properties that may be tracked with an event.
     enum Properties: String {
+        case displayName
         case viewContext
         case possibleUsers
         case receiversCount

--- a/spoti-friends/src/metrics/MetricsServiceManager.swift
+++ b/spoti-friends/src/metrics/MetricsServiceManager.swift
@@ -9,13 +9,13 @@ class MetricsServiceManager {
     }
     
     /// Tracks when a new user signs up for the app.
-    public func trackUserSignedUp() {
-        self.metricsService.trackUserSignedUp()
+    public func trackUserSignedUp(user: User) {
+        self.metricsService.trackUserSignedUp(user: user)
     }
     
     /// Tracks when the app is opened.
-    public func trackAppOpened() {
-        self.metricsService.trackAppOpened()
+    public func trackAppOpened(by user: User) {
+        self.metricsService.trackAppOpened(by: user)
     }
     
     /// Tracks when the "invite user" button is clicked and from which view.

--- a/spoti-friends/src/metrics/MetricsServiceProtocol.swift
+++ b/spoti-friends/src/metrics/MetricsServiceProtocol.swift
@@ -3,10 +3,10 @@ import Foundation
 /// A protocol that defines the methods for tracking relevant metrics.
 protocol MetricsServiceProtocol {
     /// Tracks when a new user signs up for the app.
-    func trackUserSignedUp()
+    func trackUserSignedUp(user: User)
     
-    /// Tracks when the app is opened.
-    func trackAppOpened()
+    /// Tracks when the app is opened and by whom.
+    func trackAppOpened(by: User)
     
     /// Tracks when the "invite user" button is clicked and from which view.
     func trackInvitedUser(viewContext: ViewContext, users: [SpotifyProfile]?)

--- a/spoti-friends/src/metrics/mixpanel/MixpanelMetricsService.swift
+++ b/spoti-friends/src/metrics/mixpanel/MixpanelMetricsService.swift
@@ -46,12 +46,20 @@ class MixpanelMetricsService: MetricsServiceProtocol {
     }
     
     // -- Protocol methods --
-    public func trackUserSignedUp() {
-        self.track(event: .userSignedUp)
+    public func trackUserSignedUp(user: User) {
+        let displayName = user.spotifyProfile.getDisplayName()
+        let properties: Properties = [
+            MetricsEvent.Properties.displayName.rawValue : displayName
+        ]
+        self.track(event: .userSignedUp, properties: properties)
     }
     
-    public func trackAppOpened() {
-        self.track(event: .appOpened)
+    public func trackAppOpened(by user: User) {
+        let displayName = user.spotifyProfile.getDisplayName()
+        let properties: Properties = [
+            MetricsEvent.Properties.displayName.rawValue : displayName
+        ]
+        self.track(event: .appOpened, properties: properties)
     }
     
     public func trackInvitedUser(viewContext: ViewContext, users: [SpotifyProfile]? = nil) {

--- a/spoti-friends/src/share/models/SharedResource.swift
+++ b/spoti-friends/src/share/models/SharedResource.swift
@@ -1,6 +1,21 @@
 import Foundation
 
-// TODO: Add docs. Include brief explanation on why resource is stored as a String.
+/// A representation of a resource shared between Spotify users.
+///
+/// The `SharedResource` class encapsulates information about a Spotify resource (track, artist, or album)
+/// shared between a sender and a receiver. It includes details such as the resource's type, IDs,
+/// sender and receiver profiles, timestamp of sharing, and whether the resource has been marked as listened.
+///
+/// ### Properties:
+/// - `id`: A unique identifier for the shared resource.
+/// - `resource`: The shared `SpotifyResource` object (optional, initialized later when fetched from Spotify).
+/// - `resourceId`: The Spotify ID of the resource.
+/// - `type`: The type of resource (e.g., track, artist, album).
+/// - `sender`: The Spotify profile of the sender.
+/// - `receiver`: The Spotify profile of the receiver.
+/// - `sharedTs`: The timestamp when the resource was shared.
+/// - `listened`: A flag indicating whether the resource has been listened to.
+/// 
 class SharedResource: Codable, Identifiable, Equatable {
     let id: UUID
     private var resource: SpotifyResource?
@@ -9,6 +24,7 @@ class SharedResource: Codable, Identifiable, Equatable {
     private let sender: SpotifyProfile
     private let receiver: SpotifyProfile
     private let sharedTs: TimeInterval
+    private var listened: Bool
     
     /// Implement Equatable protocol
     static func == (lhs: SharedResource, rhs: SharedResource) -> Bool {
@@ -23,6 +39,7 @@ class SharedResource: Codable, Identifiable, Equatable {
         case sender
         case receiver
         case sharedTs
+        case listened
     }
     
     /// Regular initializer for creating the object directly.
@@ -34,6 +51,7 @@ class SharedResource: Codable, Identifiable, Equatable {
         self.sender = sender
         self.receiver = receiver
         self.sharedTs = sharedTs // Defaults to current timestamp
+        self.listened = false
     }
     
     /// Custom initializer for decoding from Appwrite.
@@ -55,6 +73,7 @@ class SharedResource: Codable, Identifiable, Equatable {
         /// Converting from `Integer` to `TimeInterval` since Appwrite only supports the former.
         let sharedTsInt = try container.decode(Int.self, forKey: .sharedTs)
         self.sharedTs = TimeInterval(sharedTsInt)
+        self.listened = try container.decode(Bool.self, forKey: .listened)
     }
     
     /// Custom encode method for Appwrite
@@ -66,6 +85,7 @@ class SharedResource: Codable, Identifiable, Equatable {
         try container.encode(sender, forKey: .sender)
         try container.encode(receiver, forKey: .receiver)
         try container.encode(Int(sharedTs), forKey: .sharedTs)
+        try container.encode(listened, forKey: .listened)
     }
     
     /// Returns the type of the given resource.
@@ -80,7 +100,7 @@ class SharedResource: Codable, Identifiable, Equatable {
         }
     }
     
-    // Getters (no setters since those attributes should be immutable once initialized)
+    // Getters and setters
     public func getId() -> UUID {
         return self.id
     }
@@ -118,6 +138,18 @@ class SharedResource: Codable, Identifiable, Equatable {
     
     public func getSharedTs() -> TimeInterval {
         return self.sharedTs
+    }
+    
+    public func isListened() -> Bool {
+        return self.listened
+    }
+    
+    public func markAsListened() {
+        self.listened = true
+    }
+    
+    public func markAsNotListened() {
+        self.listened = false
     }
     
 }

--- a/spoti-friends/src/share/services/AppwriteShareService.swift
+++ b/spoti-friends/src/share/services/AppwriteShareService.swift
@@ -106,4 +106,19 @@ class AppwriteShareService: ShareServiceProtocol {
         
         return receivedResources
     }
+    
+    func markResourceAsListened(_ resource: SharedResource) async throws {
+        let data = try JSONEncoder().encode(resource)
+        try await Appwrite.shared.updateDocument(collectionId: sharedResourcesCollectionId,
+                                                 documentId: resource.getIdString(),
+                                                 data: data)
+    }
+    
+    func markResourceAsNotListened(_ resource: SharedResource) async throws {
+        resource.markAsNotListened()
+        let data = try JSONEncoder().encode(resource)
+        try await Appwrite.shared.updateDocument(collectionId: sharedResourcesCollectionId,
+                                                 documentId: resource.getIdString(),
+                                                 data: data)
+    }
 }

--- a/spoti-friends/src/share/services/ShareServiceManager.swift
+++ b/spoti-friends/src/share/services/ShareServiceManager.swift
@@ -62,4 +62,18 @@ class ShareServiceManager {
         return try await
         self.shareService.fetchReceivedResources(receiver: receiver, limit: limit, lastResourceId: lastResourceId)
     }
+    
+    /// Marks a shared resource as listened.
+    ///
+    /// - Parameter resource: The `SharedResource` object to be marked as listened.
+    func markResourceAsListened(_ resource: SharedResource) async throws -> Void {
+        try await self.shareService.markResourceAsListened(resource)
+    }
+    
+    /// Marks a shared resource as not listened.
+    ///
+    /// - Parameter resource: The `SharedResource` object to be marked as not listened.
+    func markResourceAsNotListened(_ resource: SharedResource) async throws -> Void {
+        try await self.shareService.markResourceAsNotListened(resource)
+    }
 }

--- a/spoti-friends/src/share/services/ShareServiceProtocol.swift
+++ b/spoti-friends/src/share/services/ShareServiceProtocol.swift
@@ -13,7 +13,6 @@ protocol ShareServiceProtocol {
     /// - Throws: An error if fetching the resources fails, such as network or database errors.
     func share(resource: SharedResource) async throws -> Void
     
-    
     /// Fetches a list of shared resources sent by the `sender`, with support for cursor-based pagination.
     /// This function retrieves shared resources starting after the provided `lastResourceId`,
     /// and limits the number of results based on the specified `limit`.
@@ -43,4 +42,14 @@ protocol ShareServiceProtocol {
     /// - Throws: This function throws an error if the data cannot be fetched, such as a network error or invalid data response.
     func fetchReceivedResources(receiver: SpotifyProfile, limit: Int, lastResourceId: UUID?)
     async throws -> [SharedResource]
+    
+    /// Marks a shared resource as listened.
+    ///
+    /// - Parameter resource: The `SharedResource` object to be marked as listened.
+    func markResourceAsListened(_ resource: SharedResource) async throws -> Void
+    
+    /// Marks a shared resource as not listened.
+    /// 
+    /// - Parameter resource: The `SharedResource` object to be marked as not listened.
+    func markResourceAsNotListened(_ resource: SharedResource) async throws  -> Void
 }

--- a/spoti-friends/src/share/viewModels/ShareViewModel.swift
+++ b/spoti-friends/src/share/viewModels/ShareViewModel.swift
@@ -299,6 +299,49 @@ class ShareViewModel: ObservableObject {
         }
     }
     
+    /// Marks a shared resource as listened.
+    /// This function updates both the published `receivedResources` variable and the database.
+    /// - Parameter resource: The `SharedResource` object to be marked as listened.
+    @MainActor
+    public func markResourceAsListened(_ resource: SharedResource) async {
+        do {
+            if (resource.isListened()) { return } // Return early if resource is already listened
+            
+            // Update the UI
+            resource.markAsListened()
+            if let index = receivedResources.firstIndex(where: { $0.id == resource.id }) {
+                receivedResources[index] = resource
+            }
+            
+            // Update the database
+            try await ShareServiceManager.shared.markResourceAsListened(resource)
+        } catch {
+            printError("When marking the resource (id=\(resource.getIdString())) as listened.")
+        }
+    }
+    
+    /// Marks a shared resource as not listened.
+    /// This function updates both the published `receivedResources` variable and the database.
+    ///
+    /// - Parameter resource: The `SharedResource` object to be marked as not listened.
+    @MainActor
+    public func markResourceAsNotListened(_ resource: SharedResource) async {
+        do {
+            if (!resource.isListened()) { return } // Return early if resource is already not listened
+            
+            // Update the UI
+            resource.markAsNotListened()
+            if let index = receivedResources.firstIndex(where: { $0.id == resource.id }) {
+                receivedResources[index] = resource
+            }
+            
+            // Update the database
+            try await ShareServiceManager.shared.markResourceAsNotListened(resource)
+        } catch {
+            printError("When marking the resource (id=\(resource.getIdString())) as listened.")
+        }
+    }
+    
     // TODO: Complete when implementing pagination
     public func fetchNextSearchResults () {}
 }

--- a/spoti-friends/src/share/views/home/receivedResources/ReceivedResourceView.swift
+++ b/spoti-friends/src/share/views/home/receivedResources/ReceivedResourceView.swift
@@ -10,10 +10,21 @@ import SwiftUI
 ///               It determines the type of resource and displays the appropriate view based on it.
 struct ReceivedResourceView: View {
     let resource: SharedResource
+    @EnvironmentObject var shareViewModel: ShareViewModel
+    
     var body: some View {
         HStack {
             if (resource.getType() == .track) {
-                TrackView(track: resource.getResource() as! Track)
+                let track = resource.getResource() as! Track
+                TrackView(track: track) {
+                    Task {
+                        await shareViewModel.markResourceAsListened(resource)
+                    }
+                    
+                    if let url = URL(string: track.getSpotifyUri()) {
+                        UIApplication.shared.open(url)
+                    }
+                }
             }
             
             Spacer()
@@ -27,4 +38,5 @@ struct ReceivedResourceView: View {
     let receiver = SpotifyProfileMock.michaelScott
     let resource = SharedResource(resource: TrackMock.iRememberEverything, sender: sender, receiver: receiver)
     ReceivedResourceView(resource: resource)
+        .environmentObject(ShareViewModel(user: UserMock.userJimHalpert))
 }

--- a/spoti-friends/src/share/views/home/receivedResources/ReceivedResourcesTab.swift
+++ b/spoti-friends/src/share/views/home/receivedResources/ReceivedResourcesTab.swift
@@ -19,7 +19,14 @@ struct ReceivedResourcesTab: View {
             ScrollView {
                 LazyVStack {
                     ForEach(shareViewModel.receivedResources) { resource in
-                        ReceivedResourceView(resource: resource)
+                        if (resource.isListened()) {
+                            ReceivedResourceView(resource: resource)
+                                .environmentObject(shareViewModel)
+                                .opacity(0.3)
+                        } else  {
+                            ReceivedResourceView(resource: resource)
+                                .environmentObject(shareViewModel)
+                        }
                     }
                 }
             }

--- a/spoti-friends/src/share/views/home/sentResources/ReceiversSheetView.swift
+++ b/spoti-friends/src/share/views/home/sentResources/ReceiversSheetView.swift
@@ -22,7 +22,7 @@ struct ReceiversSheetView: View {
             // Preview of track to send
             if (resource.getType() == .track) {
                 TrackView(track: resource.getResource() as! Track) {
-                    ()
+                    () // Overriding the onTapGesture to do nothing
                 }
                 .padding(.horizontal)
             }

--- a/spoti-friends/src/spotifriendsApp.swift
+++ b/spoti-friends/src/spotifriendsApp.swift
@@ -21,7 +21,7 @@ struct spoti_friendsApp: App {
                         }
                         
                         try await fetchAndCacheDataOnAppLoad(signedInUser: signedInUser)
-                        MetricsServiceManager.shared.trackAppOpened()
+                        MetricsServiceManager.shared.trackAppOpened(by: signedInUser)
                     }
                 }
         }


### PR DESCRIPTION
### Checklist
- [x] Added documentation to all classes and functions
- [x] Added new metrics if required
- [x] Verified Appwrite Project ID is set to `friends-fm` (and not `friends-fm-DEV`)

**If merging to `main`**
  - [ ] Incremented the version number
  - [ ] Created a new changelog view

### Changes
- Added a `status` attribute to `SharedResource` and marked a received resource as listened when it is clicked
- Updated the `appOpened` and `userSignedUp` metrics to include display name as a property
