### PR TITLE
Hotfix: Fixed bug where persisted user was not being set and cleared correctly

### DIFF
--- a/spoti-friends/src/auth/viewModels/AuthorizationViewModel.swift
+++ b/spoti-friends/src/auth/viewModels/AuthorizationViewModel.swift
@@ -48,6 +48,29 @@ class AuthorizationViewModel: ObservableObject {
         }
     }
     
+    /// Fetches and caches data for the signed-in user during app load.
+    ///
+    /// This function fetches and caches the following data:
+    ///   - `signedInUser`
+    ///   - `receivedResources`
+    ///   - `sentResources`
+    ///
+    /// - Parameter signedInUser: The currently signed-in user.
+    /// - Throws: An error if fetching the received or sent resources from `ShareServiceManager` fails.
+    ///
+    func fetchAndCacheDataOnAppLoad(signedInUser: User) async throws {
+        PersistedStorage.shared.persistUser(signedInUser)
+        printInfo("Persisted signed in user")
+        
+        let userProfile = signedInUser.spotifyProfile
+        let receivedResources = try await ShareServiceManager.shared.fetchReceivedResources(receiver: userProfile)
+        Cache.shared.cacheReceivedResources(receivedResources, spotifyId: signedInUser.spotifyId)
+        printInfo("Cached received resources for user (id=\(signedInUser.spotifyId))")
+        
+        let sentResources = try await ShareServiceManager.shared.fetchSentResources(sender: userProfile)
+        Cache.shared.cacheSentResources(sentResources, spotifyId: signedInUser.spotifyId)
+        printInfo("Cached sent resources for user (id=\(signedInUser.spotifyId))")
+    }
     
     /// Signs out the currently signed in user.
     @MainActor
@@ -60,6 +83,7 @@ class AuthorizationViewModel: ObservableObject {
             }
         }
         
+        PersistedStorage.shared.clearPersistedUser()
         storeInUserDefaults(key: "signedInUserId", value: "")
         storeInUserDefaults(key: "code_verifier", value: "")
         self.user = nil

--- a/spoti-friends/src/common/models/PersistedStorage.swift
+++ b/spoti-friends/src/common/models/PersistedStorage.swift
@@ -21,4 +21,9 @@ class PersistedStorage {
     public func getSignedInUser() -> User? {
         return self.signedInUser
     }
+    
+    /// Clears the persisted signed in user.
+    public func clearPersistedUser() {
+        self.signedInUser = nil
+    }
 }

--- a/spoti-friends/src/common/views/AuthenticatedView.swift
+++ b/spoti-friends/src/common/views/AuthenticatedView.swift
@@ -48,6 +48,12 @@ struct AuthenticatedView: View {
                 printError("Expected user but found none (AuthenticatedView)")
                 return
             }
+            Task {
+                try await authorizationViewModel.fetchAndCacheDataOnAppLoad(signedInUser: signedInUser)
+            }
+            
+            print("woop")
+            
             friendActivityViewModel.user = signedInUser
             shareViewModel.user = signedInUser
             profileViewModel.user = signedInUser

--- a/spoti-friends/src/share/services/AppwriteShareService.swift
+++ b/spoti-friends/src/share/services/AppwriteShareService.swift
@@ -35,8 +35,8 @@ class AppwriteShareService: ShareServiceProtocol {
         
         // Convert each document to a SharedResource and return as an array
         let signedInUser: User
-        if let cachedUser = PersistedStorage.shared.getSignedInUser() {
-            signedInUser = cachedUser
+        if let persistedUser = PersistedStorage.shared.getSignedInUser() {
+            signedInUser = persistedUser
         } else {
             signedInUser = try await UserServiceManager.shared.getUserFromDB(withSpotifyId: sender.getSpotifyId())
         }
@@ -82,8 +82,8 @@ class AppwriteShareService: ShareServiceProtocol {
         
         // Convert each document to a SharedResource and return as an array
         let signedInUser: User
-        if let cachedUser = PersistedStorage.shared.getSignedInUser() {
-            signedInUser = cachedUser
+        if let persistedUser = PersistedStorage.shared.getSignedInUser() {
+            signedInUser = persistedUser
         } else {
             signedInUser = try await UserServiceManager.shared.getUserFromDB(withSpotifyId: receiver.getSpotifyId())
         }

--- a/spoti-friends/src/spotifriendsApp.swift
+++ b/spoti-friends/src/spotifriendsApp.swift
@@ -21,8 +21,6 @@ struct spoti_friendsApp: App {
                                 print("App Version: \(appVersion)")
                                 storeInUserDefaults(key: "appVersion", value: appVersion)
                             }
-                            
-                            try await fetchAndCacheDataOnAppLoad(signedInUser: signedInUser)
                         }
                     }
                 
@@ -36,28 +34,4 @@ struct spoti_friendsApp: App {
             }
         }
     }
-}
-
-/// Fetches and caches data for the signed-in user during app load.
-///
-/// This function fetches and caches the following data:
-///   - `signedInUser`
-///   - `receivedResources`
-///   - `sentResources`
-///
-/// - Parameter signedInUser: The currently signed-in user.
-/// - Throws: An error if fetching the received or sent resources from `ShareServiceManager` fails.
-///
-func fetchAndCacheDataOnAppLoad(signedInUser: User) async throws {
-    PersistedStorage.shared.persistUser(signedInUser)
-    printInfo("Persisted signed in user")
-    
-    let userProfile = signedInUser.spotifyProfile
-    let receivedResources = try await ShareServiceManager.shared.fetchReceivedResources(receiver: userProfile)
-    Cache.shared.cacheReceivedResources(receivedResources, spotifyId: signedInUser.spotifyId)
-    printInfo("Cached received resources for user (id=\(signedInUser.spotifyId))")
-    
-    let sentResources = try await ShareServiceManager.shared.fetchSentResources(sender: userProfile)
-    Cache.shared.cacheSentResources(sentResources, spotifyId: signedInUser.spotifyId)
-    printInfo("Cached sent resources for user (id=\(signedInUser.spotifyId))")
 }


### PR DESCRIPTION
### Checklist
- [x] Added documentation to all classes and functions
- [x] Added new metrics if required
- [x] Verified Appwrite Project ID is set to `friends-fm` (and not `friends-fm-DEV`)

**If merging to `main`**
  - [ ] Incremented the version number
  - [ ] Created a new changelog view

### Changes
- Fixed bug where the persisted user was not being set and cleared correctly
    - Now we persist the user when the `AuthenticatedView` appears, instead of `RootView`
    - We also clear the persisted user on log out